### PR TITLE
Refresh PowerShell distro workflows

### DIFF
--- a/.github/workflows/dotnet-runtime.yml
+++ b/.github/workflows/dotnet-runtime.yml
@@ -1,5 +1,12 @@
 name: .NET runtime
 on: workflow_dispatch
+env:
+  DOTNET_RUNTIME_VERSION: "10.0.5"
+  DOTNET_RUNTIME_REF: "v10.0.5"
+  CLANG_LLVM_VERSION: "22.1.4"
+  CLANG_LLVM_RELEASE: "v2026.1.1"
+  VSDEVSHELL_VERSION: "2026.1.0"
+  VSDEVSHELL_REF: "9b4518e6c45a2abedbf6a05b77c9912aaef70f1e"
 jobs:
   build:
     name: .NET runtime [${{matrix.arch}}-${{matrix.os}}]
@@ -7,26 +14,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x86_64 ]
-        os: [ windows, macos, linux ]
-        version: [ 8.0.1 ]
-
         include:
-          - version: 8.0.1
-            git-ref: v8.0.1
-
           - os: windows
-            runner: windows-2022
+            arch: x86_64
+            runtime-arch: x64
+            vs-arch: x64
+            llvm-arch: x86_64
+            runner: windows-2025
+            llvm-platform: windows
+          - os: windows
+            arch: arm64
+            runtime-arch: arm64
+            vs-arch: arm64
+            llvm-arch: x86_64
+            runner: windows-2025
+            llvm-platform: windows
           - os: macos
-            runner: macos-13
+            arch: x86_64
+            runtime-arch: x64
+            llvm-arch: x86_64
+            runner: macos-15-intel
+            llvm-platform: macos
+          - os: macos
+            arch: arm64
+            runtime-arch: arm64
+            llvm-arch: aarch64
+            runner: macos-15
+            llvm-platform: macos
           - os: linux
-            runner: ubuntu-22.04
+            arch: x86_64
+            runtime-arch: x64
+            llvm-arch: x86_64
+            runner: ubuntu-24.04
+            llvm-platform: ubuntu-24.04
+          - os: linux
+            arch: arm64
+            runtime-arch: arm64
+            llvm-arch: aarch64
+            runner: ubuntu-24.04-arm
+            llvm-platform: ubuntu-24.04
   
     steps:
       - name: Configure Windows runner
         if: runner.os == 'Windows'
         run: |
-          choco install ninja 7zip wget
+          choco install ninja 7zip
           git config --system core.longpaths true
           echo "BUILD_CMD=./build.cmd" >> $Env:GITHUB_ENV
 
@@ -34,25 +66,49 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install ninja
-          echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV
+          echo "CLR_CC=/usr/bin/clang" >> $GITHUB_ENV
+          echo "CLR_CXX=/usr/bin/clang++" >> $GITHUB_ENV
           echo "BUILD_CMD=./build.sh" >> $GITHUB_ENV
 
       - name: Configure Linux runner
         if: runner.os == 'Linux'
         run: |
-          sudo apt update
-          sudo apt install git xz-utils ninja-build
-          sudo apt install libkrb5-dev liblttng-ust-dev
+          sudo apt-get update
+          sudo apt-get install -y git xz-utils ninja-build build-essential
+          sudo apt-get install -y libkrb5-dev liblttng-ust-dev
+          if [ "${{matrix.runtime-arch}}" = "arm64" ]; then
+            sudo tee /usr/local/bin/clang-dotnet >/dev/null <<'EOF'
+          #!/usr/bin/env bash
+          if [ -x /opt/llvm/bin/clang-22 ]; then
+            exec /opt/llvm/bin/clang-22 --target=aarch64-linux-gnu --gcc-toolchain=/usr --sysroot=/ "$@"
+          fi
+          exec /opt/llvm/bin/clang --target=aarch64-linux-gnu --gcc-toolchain=/usr --sysroot=/ "$@"
+          EOF
+            sudo tee /usr/local/bin/clang++-dotnet >/dev/null <<'EOF'
+          #!/usr/bin/env bash
+          if [ -x /opt/llvm/bin/clang++-22 ]; then
+            exec /opt/llvm/bin/clang++-22 --target=aarch64-linux-gnu --gcc-toolchain=/usr --sysroot=/ "$@"
+          fi
+          if [ -x /opt/llvm/bin/clang++ ]; then
+            exec /opt/llvm/bin/clang++ --target=aarch64-linux-gnu --gcc-toolchain=/usr --sysroot=/ "$@"
+          fi
+          exec /opt/llvm/bin/clang-22 --driver-mode=g++ --target=aarch64-linux-gnu --gcc-toolchain=/usr --sysroot=/ "$@"
+          EOF
+            sudo chmod +x /usr/local/bin/clang-dotnet /usr/local/bin/clang++-dotnet
+            echo "CLR_CC=/usr/local/bin/clang-dotnet" >> $GITHUB_ENV
+            echo "CLR_CXX=/usr/local/bin/clang++-dotnet" >> $GITHUB_ENV
+          fi
           echo "BUILD_CMD=./build.sh" >> $GITHUB_ENV
 
       - name: Install clang+llvm
         shell: pwsh
         run: |
-          $ClangLlvmVersion='16.0.6'
-          $ClangLlvmPlatform = @{'windows'='windows';'macos'='macos';'linux'='ubuntu-20.04'}['${{matrix.os}}']
-          $ClangLlvmBaseUrl="https://github.com/awakecoding/llvm-prebuilt/releases/download/v2023.3.0"
-          $ClangLlvmName="clang+llvm-${ClangLlvmVersion}-x86_64-${ClangLlvmPlatform}"
-          wget "${ClangLlvmBaseUrl}/${ClangLlvmName}.tar.xz"
+          $ClangLlvmVersion = $Env:CLANG_LLVM_VERSION
+          $ClangLlvmPlatform = '${{matrix.llvm-platform}}'
+          $ClangLlvmBaseUrl = "https://github.com/awakecoding/llvm-prebuilt/releases/download/$Env:CLANG_LLVM_RELEASE"
+          $ClangLlvmName="clang+llvm-${ClangLlvmVersion}-${{matrix.llvm-arch}}-${ClangLlvmPlatform}"
+          Invoke-WebRequest "${ClangLlvmBaseUrl}/${ClangLlvmName}.tar.xz" -OutFile "${ClangLlvmName}.tar.xz"
           if ($IsWindows) {
             $LLVM_PREFIX="C:/llvm"
             cmd.exe /c "7z.exe x ${ClangLlvmName}.tar.xz -so | 7z x -si -ttar -o`"C:/temp`""
@@ -65,29 +121,97 @@ jobs:
           $LLVM_BIN_PATH="$LLVM_PREFIX/bin"
           $LLVM_DIR="$LLVM_PREFIX/lib/cmake/llvm"
           echo "LLVM_DIR=$LLVM_DIR" >> $Env:GITHUB_ENV
-          echo "PATH=$LLVM_BIN_PATH$([IO.Path]::PathSeparator)$Env:PATH" >> $Env:GITHUB_ENV
+          if ('${{matrix.os}}' -ne 'macos') {
+            echo "PATH=$LLVM_BIN_PATH$([IO.Path]::PathSeparator)$Env:PATH" >> $Env:GITHUB_ENV
+          }
 
-      - name: Clone .NET runtime ${{matrix.version}}
-        uses: actions/checkout@v4
+      - name: Clone .NET runtime ${{env.DOTNET_RUNTIME_VERSION}}
+        uses: actions/checkout@v7.0.0
         with:
           repository: dotnet/runtime
-          ref: ${{matrix.git-ref}}
+          ref: ${{env.DOTNET_RUNTIME_REF}}
           path: dotnet-runtime
+
+      - name: Clone VsDevShell ${{env.VSDEVSHELL_VERSION}}
+        if: runner.os == 'Windows'
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: awakecoding/VsDevShell
+          ref: ${{env.VSDEVSHELL_REF}}
+          path: VsDevShell
 
       - name: Enable Windows environment
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: amd64
+        shell: pwsh
+        run: |
+          Import-Module "./VsDevShell/VsDevShell/VsDevShell.psd1" -Force
+          $BaselinePath = $Env:PATH
+          $VsDevEnv = Get-VsDevEnv -Arch '${{matrix.vs-arch}}' -HostArch x64
+
+          function Add-GitHubEnvValue {
+            param(
+              [Parameter(Mandatory)]
+              [string] $Name,
+              [AllowNull()]
+              [string] $Value
+            )
+
+            if ($null -eq $Value) {
+              $Value = ''
+            }
+
+            if ($Value -match "[`r`n]") {
+              $Delimiter = "VSDEVENV_$([Guid]::NewGuid().ToString('N'))"
+              @(
+                "$Name<<$Delimiter",
+                $Value,
+                $Delimiter
+              ) -join [Environment]::NewLine >> $Env:GITHUB_ENV
+            } else {
+              "$Name=$Value" >> $Env:GITHUB_ENV
+            }
+          }
+
+          foreach ($Entry in $VsDevEnv.GetEnumerator()) {
+            $Name = [string] $Entry.Key
+            $Value = if ($null -eq $Entry.Value) { $null } else { [string] $Entry.Value }
+
+            if ($Name.Equals('PATH', [StringComparison]::OrdinalIgnoreCase) -and
+                -not [string]::IsNullOrEmpty($Value) -and
+                -not [string]::IsNullOrEmpty($Env:GITHUB_PATH)) {
+              if (-not [string]::IsNullOrEmpty($BaselinePath) -and
+                  $Value.EndsWith($BaselinePath, [StringComparison]::OrdinalIgnoreCase)) {
+                $Prefix = $Value.Substring(0, $Value.Length - $BaselinePath.Length).TrimEnd(';')
+                $Prefix -split ';' |
+                  Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                  ForEach-Object { $_ >> $Env:GITHUB_PATH }
+                continue
+              }
+            }
+
+            if ([string]::IsNullOrWhiteSpace($Name) -or $Name.Contains('=')) {
+              continue
+            }
+
+            Add-GitHubEnvValue -Name $Name -Value $Value
+          }
 
       - name: Restore nuget packages
         working-directory: dotnet-runtime
         shell: pwsh
         run: |
-          & $Env:BUILD_CMD -restore
+          if ($IsWindows) {
+            & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -restore
+          } else {
+            & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -restore
+          }
 
       - name: Build .NET runtime
         working-directory: dotnet-runtime
         shell: pwsh
         run: |
-          & $Env:BUILD_CMD -c Release -ninja
+          if ($IsWindows) {
+            & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -c Release -ninja
+          } else {
+            & $Env:BUILD_CMD -arch '${{matrix.runtime-arch}}' -c Release -ninja
+          }

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -1,53 +1,82 @@
 name: PowerShell SDK
 on: workflow_dispatch
+env:
+  POWERSHELL_VERSION: "7.6.3"
+  POWERSHELL_REF: "v7.6.3"
 jobs:
   build:
-    name: PowerShell SDK
-    runs-on: ubuntu-20.04
+    name: PowerShell SDK [7.6.3]
+    runs-on: ubuntu-24.04
   
     steps:
       - name: Clone project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
-      - name: Clone PowerShell
-        uses: actions/checkout@v4
+      - name: Clone PowerShell ${{env.POWERSHELL_VERSION}}
+        uses: actions/checkout@v7.0.0
         with:
           repository: PowerShell/PowerShell
-          ref: v7.4.1
+          ref: ${{env.POWERSHELL_REF}}
           path: PowerShell
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5.3.0
+        with:
+          global-json-file: PowerShell/global.json
+
+      - name: Install Mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-devel
+
+      - name: Setup NuGet CLI
+        uses: NuGet/setup-nuget@v4.0
 
       - name: Build PowerShell SDK
         shell: pwsh
         working-directory: PowerShell
         run: |
+          $ErrorActionPreference = 'Stop'
           Import-Module .\build.psm1 -Force
-          Start-PSBootstrap
-          Start-PSBuild -Clean -PSModuleRestore -Configuration Release
+          Start-PSBootstrap -Scenario DotNet
+          Start-PSBuild -Clean -PSModuleRestore -Configuration Release -ReleaseTag $Env:POWERSHELL_REF -UseNuGetOrg
+
+          [xml]$CommonProps = Get-Content ./PowerShell.Common.props
+          $TargetFramework = $CommonProps.Project.PropertyGroup |
+            ForEach-Object { $_.TargetFramework } |
+            Where-Object { $_ } |
+            Select-Object -First 1
+          if (-not $TargetFramework) {
+            throw "Unable to determine PowerShell TargetFramework from PowerShell.Common.props"
+          }
+
+          $SdkBinPath = "./src/Microsoft.PowerShell.SDK/bin/Release/$TargetFramework"
+          dotnet build ./src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj -c Release /p:ReleaseTag=$Env:POWERSHELL_VERSION
+
           Remove-Item .\nupkg-out -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
           New-Item .\nupkg-out -ItemType Directory -Force
-          dotnet build ./src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj -c Release
-          New-Item ./nupkg-out/unix/lib/net8.0 -ItemType Directory | Out-Null
-          New-Item ./nupkg-out/ref/net8.0 -ItemType Directory | Out-Null
-          Copy-Item ./src/Microsoft.PowerShell.SDK/bin/Release/net8.0/Microsoft.PowerShell.SDK*.dll ./nupkg-out/unix/lib/net8.0
-          Copy-Item ./src/Microsoft.PowerShell.SDK/bin/Release/net8.0/Microsoft.PowerShell.SDK*.xml ./nupkg-out/unix/lib/net8.0
-          Copy-Item ./src/Microsoft.PowerShell.SDK/bin/Release/net8.0/*.dll ./nupkg-out/ref/net8.0
-          Copy-Item ./src/Microsoft.PowerShell.SDK/bin/Release/net8.0/*.xml ./nupkg-out/ref/net8.0
+          New-Item "./nupkg-out/unix/lib/$TargetFramework" -ItemType Directory | Out-Null
+          New-Item "./nupkg-out/ref/$TargetFramework" -ItemType Directory | Out-Null
+          Copy-Item "$SdkBinPath/Microsoft.PowerShell.SDK*.dll" "./nupkg-out/unix/lib/$TargetFramework"
+          Copy-Item "$SdkBinPath/Microsoft.PowerShell.SDK*.xml" "./nupkg-out/unix/lib/$TargetFramework"
+          Copy-Item "$SdkBinPath/*.dll" "./nupkg-out/ref/$TargetFramework"
+          Copy-Item "$SdkBinPath/*.xml" "./nupkg-out/ref/$TargetFramework"
           $AnyAnyRuntimesDir = "./nupkg-out/contentFiles/any/any/runtimes"
           New-Item $AnyAnyRuntimesDir -ItemType Directory | Out-Null
           Get-Item ./src/Modules/Unix/*/*.ps* | ForEach-Object {
-            ($ModuleName, $ModuleFile) = ($_.FullName -Replace ".*src/Modules/Unix/","") -Split "/"
-            $DestinationDir = "$AnyAnyRuntimesDir/unix/lib/net8.0/Modules/$ModuleName"
+            $ModuleName = Split-Path (Split-Path $_.FullName -Parent) -Leaf
+            $DestinationDir = "$AnyAnyRuntimesDir/unix/lib/$TargetFramework/Modules/$ModuleName"
             New-Item $DestinationDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
             Copy-Item $_ $DestinationDir
           }
           Get-Item ./src/Modules/Windows/*/*.ps* | ForEach-Object {
-            ($ModuleName, $ModuleFile) = ($_.FullName -Replace ".*src/Modules/Windows/","") -Split "/"
-            $DestinationDir = "$AnyAnyRuntimesDir/win/lib/net8.0/Modules/$ModuleName"
+            $ModuleName = Split-Path (Split-Path $_.FullName -Parent) -Leaf
+            $DestinationDir = "$AnyAnyRuntimesDir/win/lib/$TargetFramework/Modules/$ModuleName"
             New-Item $DestinationDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
             Copy-Item $_ $DestinationDir
           }
-          $PSVersion = Get-PSVersion -OmitCommitId
-          wget "https://www.nuget.org/api/v2/package/Microsoft.PowerShell.SDK/$PSVersion" -O "Microsoft.PowerShell.SDK.${PSVersion}.nupkg"
+          $PSVersion = $Env:POWERSHELL_VERSION
+          Invoke-WebRequest "https://www.nuget.org/api/v2/package/Microsoft.PowerShell.SDK/$PSVersion" -OutFile "Microsoft.PowerShell.SDK.${PSVersion}.nupkg"
           Remove-Item ./nupkg-prod -Recurse -Force -ErrorAction SilentlyContinue
           Expand-Archive "./Microsoft.PowerShell.SDK.${PSVersion}.nupkg" nupkg-prod
           Get-ChildItem -Path ./nupkg-prod -Include @('*.nuspec','*.png','*.xml') -Recurse -Depth 1 | % { Copy-Item $_ ./nupkg-out -Force }
@@ -55,14 +84,14 @@ jobs:
           Copy-Item "./nupkg-prod/*.png" ./nupkg-out/ -Force
           Remove-Item ./nupkg-out/contentFiles/any/any/ref -Recurse -Force -ErrorAction SilentlyContinue
           Copy-Item ./nupkg-prod/contentFiles/any/any/ref ./nupkg-out/contentFiles/any/any/ref -Recurse
-          New-Item "./package" -ItemType Directory | Out-Null
-          Set-Location ./nupkg-out
+          New-Item "./package" -ItemType Directory -Force | Out-Null
+          Push-Location ./nupkg-out
           nuget pack
           Move-Item *.nupkg ../package
-          Set-Location ..
+          Pop-Location
 
       - name: Upload PowerShell package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: PowerShell-SDK
+          name: PowerShell-SDK-${{env.POWERSHELL_VERSION}}
           path: "PowerShell/package/*.nupkg"

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -1,5 +1,8 @@
 name: PowerShell
 on: workflow_dispatch
+env:
+  POWERSHELL_VERSION: "7.6.3"
+  POWERSHELL_REF: "v7.6.3"
 jobs:
   build:
     name: PowerShell [${{matrix.arch}}-${{matrix.os}}]
@@ -7,55 +10,76 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, arm64 ]
-        os: [ windows, macos, linux ]
-        version: [ 7.4.1 ]
-
         include:
-          - version: 7.4.1
-            git-ref: v7.4.1
-
           - os: windows
-            runner: windows-2022
+            arch: x64
+            runner: windows-2025
+            runtime-os: win7
+          - os: windows
+            arch: arm64
+            runner: windows-2025
+            runtime-os: win
           - os: macos
-            runner: macos-13
+            arch: x64
+            runner: macos-15-intel
+            runtime-os: osx
+          - os: macos
+            arch: arm64
+            runner: macos-15
+            runtime-os: osx
           - os: linux
-            runner: ubuntu-22.04
+            arch: x64
+            runner: ubuntu-24.04
+            runtime-os: linux
+          - os: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+            runtime-os: linux
   
     steps:
       - name: Clone project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
-      - name: Clone PowerShell ${{matrix.version}}
-        uses: actions/checkout@v4
+      - name: Clone PowerShell ${{env.POWERSHELL_VERSION}}
+        uses: actions/checkout@v7.0.0
         with:
           repository: PowerShell/PowerShell
-          ref: ${{matrix.git-ref}}
+          ref: ${{env.POWERSHELL_REF}}
           path: PowerShell
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5.3.0
+        with:
+          global-json-file: PowerShell/global.json
 
       - name: Bootstrap PowerShell
         shell: pwsh
         run: |
           Import-Module "./PowerShell/build.psm1" -Force
-          Start-PSBootstrap
+          Start-PSBootstrap -Scenario DotNet
 
       - name: Build PowerShell
         shell: pwsh
         run: |
           Import-Module "./PowerShell/build.psm1" -Force
-          Start-PSBootstrap
-
-      - name: Build PowerShell
-        shell: pwsh
-        run: |
-          Import-Module "./PowerShell/build.psm1" -Force
-          $DotNetOs = @{'windows'='win';'macos'='osx';'linux'='linux'}['${{matrix.os}}']
-          $DotNetArch = '${{matrix.arch}}'
-          if (($DotNetOs -eq 'win') -and ($DotNetArch -eq 'x64')){
-            $DotNetOs = "win7"
+          if ('${{matrix.os}}' -eq 'windows') {
+            Switch-PSNugetConfig -Source Public
+            $ModuleNugetConfig = @(
+              '<?xml version="1.0" encoding="utf-8"?>',
+              '<configuration>',
+              '  <packageSources>',
+              '    <clear />',
+              '    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />',
+              '  </packageSources>',
+              '  <disabledPackageSources>',
+              '    <clear />',
+              '  </disabledPackageSources>',
+              '</configuration>'
+            )
+            Set-Content -Path "./PowerShell/src/Modules/nuget.config" -Value $ModuleNugetConfig -Encoding utf8
           }
-          $Runtime = "${DotNetOs}-${{matrix.arch}}"
-          $OutputPath = Join-Path $PWD "PowerShell-${{matrix.version}}-${{matrix.os}}-${{matrix.arch}}"
+          $Runtime = "${{matrix.runtime-os}}-${{matrix.arch}}"
+          $OutputPath = Join-Path $PWD "PowerShell-$Env:POWERSHELL_VERSION-${{matrix.os}}-${{matrix.arch}}"
           $ArchiveFile = "$OutputPath.tar.gz"
           $PSBuildParams = @{
             Configuration = "Release";
@@ -64,12 +88,16 @@ jobs:
             ForMinimalSize = $false;
             Detailed = $true;
             Clean = $true;
+            ReleaseTag = $Env:POWERSHELL_REF;
+          }
+          if ('${{matrix.os}}' -ne 'windows') {
+            $PSBuildParams.UseNuGetOrg = $true
           }
           Start-PSBuild @PSBuildParams
           & 'tar' '-czf' "$ArchiveFile" '-C' "$OutputPath" "."
 
       - name: Upload PowerShell package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: PowerShell-${{matrix.version}}-${{matrix.os}}-${{matrix.arch}}
-          path: PowerShell-${{matrix.version}}-${{matrix.os}}-${{matrix.arch}}.tar.gz
+          name: PowerShell-${{env.POWERSHELL_VERSION}}-${{matrix.os}}-${{matrix.arch}}
+          path: PowerShell-${{env.POWERSHELL_VERSION}}-${{matrix.os}}-${{matrix.arch}}.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 PowerShell/
+dotnet-runtime/
 output/
-
+package/
+*.nupkg
+*.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent instructions
+
+This repository is a small GitHub Actions project for building PowerShell distribution artifacts. Treat `.github/workflows/powershell-sdk.yml` as the primary product surface and `.github/workflows/powershell.yml` as the secondary product surface.
+
+Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version/ref in both PowerShell workflows, verify the upstream target framework from `PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
+
+The `.NET runtime` workflow uses `awakecoding/llvm-prebuilt` assets. When refreshing it, verify the release tag and required `clang+llvm-<version>-x86_64-<platform>.tar.xz` assets exist before changing `CLANG_LLVM_VERSION`, `CLANG_LLVM_RELEASE`, or runner OS labels.
+
+Do not commit generated `PowerShell/`, `dotnet-runtime/`, package, archive, or build output directories. Prefer validating workflow edits with a YAML parser and `git diff --check` before finishing.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# pwsh-distro
+
+GitHub Actions workflows for building redistributable PowerShell artifacts from upstream source. The primary target is a refreshed `Microsoft.PowerShell.SDK` package, and the secondary target is a self-contained PowerShell distribution archive.
+
+## Current pins
+
+| Component | Version |
+| --- | --- |
+| PowerShell | `7.6.3` / `v7.6.3` |
+| PowerShell target framework | `net10.0` |
+| .NET runtime workflow | `v10.0.5` |
+| llvm-prebuilt | `v2026.1.1` |
+| clang+llvm | `22.1.4` |
+| VsDevShell | `2026.1.0` / `9b4518e6c45a2abedbf6a05b77c9912aaef70f1e` |
+
+## Workflows
+
+| Workflow | Purpose | Output |
+| --- | --- | --- |
+| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source and repacks `Microsoft.PowerShell.SDK` for the upstream target framework. | `PowerShell-SDK-7.6.3` artifact containing a `.nupkg`. |
+| `.github/workflows/powershell.yml` | Builds self-contained PowerShell archives for Windows, macOS, and Linux on x64 and arm64. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
+| `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
+
+All workflows are manual and can be started from the GitHub Actions **Run workflow** button.
+
+## Notes
+
+The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from the locally built SDK binaries plus metadata, reference assemblies, and content layout from the official NuGet package for the same PowerShell version.
+
+Generated source checkouts and build artifacts are not part of this repository.


### PR DESCRIPTION
## Summary
- Add README and AGENTS guidance for maintaining the workflow-based distro experiment.
- Refresh PowerShell SDK and PowerShell distro workflows for PowerShell 7.6.3, deriving the SDK target framework from upstream PowerShell props.
- Update GitHub Actions usage to Node 24-compatible action versions and replace the Visual Studio setup action with pinned VsDevShell.
- Refresh the .NET runtime workflow to .NET 10.0.5 / llvm-prebuilt v2026.1.1 and expand runtime coverage to x86_64 and arm64 on Windows, macOS, and Linux.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false`
- `git diff --check`
- PowerShell SDK workflow: 27780072670
- PowerShell workflow: 27780074248
- .NET runtime workflow: 27787428200

The squashed commit tree matches the green pre-squash tree.