### PR TITLE
Add opt-in PowerShell SDK apphost packaging

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -160,6 +160,7 @@ jobs:
           if (-not $TargetFramework) {
             throw "Unable to determine PowerShell TargetFramework from PowerShell.Common.props"
           }
+          "POWERSHELL_TARGET_FRAMEWORK=$TargetFramework" >> $Env:GITHUB_ENV
 
           $SdkBinPath = "./src/Microsoft.PowerShell.SDK/bin/Release/$TargetFramework"
           dotnet build ./src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj -c Release /p:ReleaseTag=$Env:POWERSHELL_VERSION
@@ -231,6 +232,16 @@ jobs:
           nuget pack
           Move-Item *.nupkg ../package
           Pop-Location
+
+      - name: Validate PowerShell SDK package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./eng/Validate-PowerShellSdkPackage.ps1 `
+            -PackageDirectory ./PowerShell/package `
+            -PowerShellVersion $Env:POWERSHELL_VERSION `
+            -TargetFramework $Env:POWERSHELL_TARGET_FRAMEWORK `
+            -RuntimeIdentifier linux-x64
 
       - name: Upload PowerShell package
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -129,7 +129,7 @@ jobs:
           global-json-file: PowerShell/global.json
 
       - name: Download PowerShell apphosts
-        uses: actions/download-artifact@v7.0.1
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: PowerShell-SDK-AppHost-*
           path: apphost-download

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -4,9 +4,113 @@ env:
   POWERSHELL_VERSION: "7.6.3"
   POWERSHELL_REF: "v7.6.3"
 jobs:
+  apphost:
+    name: PowerShell SDK apphost [${{matrix.rid}}]
+    runs-on: ${{matrix.runner}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            runner: windows-2025
+            psbuild-runtime: fxdependent-win-desktop
+            executable: pwsh.exe
+          - rid: linux-x64
+            runner: ubuntu-24.04
+            psbuild-runtime: fxdependent-linux-x64
+            executable: pwsh
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+            psbuild-runtime: fxdependent-linux-arm64
+            executable: pwsh
+          - rid: osx-x64
+            runner: macos-15-intel
+            psbuild-runtime: fxdependent
+            executable: pwsh
+          - rid: osx-arm64
+            runner: macos-15
+            psbuild-runtime: fxdependent
+            executable: pwsh
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v7.0.0
+
+      - name: Clone PowerShell ${{env.POWERSHELL_VERSION}}
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: PowerShell/PowerShell
+          ref: ${{env.POWERSHELL_REF}}
+          path: PowerShell
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5.3.0
+        with:
+          global-json-file: PowerShell/global.json
+
+      - name: Build PowerShell apphost
+        shell: pwsh
+        working-directory: PowerShell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Import-Module .\build.psm1 -Force
+          Start-PSBootstrap -Scenario DotNet
+
+          if ($IsWindows) {
+            Switch-PSNugetConfig -Source Public
+            $ModuleNugetConfig = @(
+              '<?xml version="1.0" encoding="utf-8"?>',
+              '<configuration>',
+              '  <packageSources>',
+              '    <clear />',
+              '    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />',
+              '  </packageSources>',
+              '  <disabledPackageSources>',
+              '    <clear />',
+              '  </disabledPackageSources>',
+              '</configuration>'
+            )
+            Set-Content -Path "./src/Modules/nuget.config" -Value $ModuleNugetConfig -Encoding utf8
+          }
+
+          $Rid = "${{matrix.rid}}"
+          $OutputPath = Join-Path $PWD "PowerShell-AppHost-$Rid"
+          $PSBuildParams = @{
+            Configuration = "Release";
+            Runtime = "${{matrix.psbuild-runtime}}";
+            Output = $OutputPath;
+            Clean = $true;
+            ReleaseTag = $Env:POWERSHELL_REF;
+            NoPSModuleRestore = $true;
+            SkipExperimentalFeatureGeneration = $true;
+          }
+          if (-not $IsWindows) {
+            $PSBuildParams.UseNuGetOrg = $true
+          }
+
+          Start-PSBuild @PSBuildParams
+
+          $StagePath = Join-Path (Join-Path $PWD "apphost-package") $Rid
+          New-Item $StagePath -ItemType Directory -Force | Out-Null
+          $RequiredFiles = @("${{matrix.executable}}", "pwsh.dll", "pwsh.runtimeconfig.json")
+          foreach ($FileName in $RequiredFiles) {
+            $SourcePath = Join-Path $OutputPath $FileName
+            if (-not (Test-Path $SourcePath -PathType Leaf)) {
+              throw "PowerShell apphost build did not produce required file: $SourcePath"
+            }
+            Copy-Item $SourcePath $StagePath -Force
+          }
+
+      - name: Upload PowerShell apphost
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: PowerShell-SDK-AppHost-${{matrix.rid}}
+          path: PowerShell/apphost-package/${{matrix.rid}}/*
+
   build:
     name: PowerShell SDK [7.6.3]
     runs-on: ubuntu-24.04
+    needs: apphost
   
     steps:
       - name: Clone project
@@ -23,6 +127,13 @@ jobs:
         uses: actions/setup-dotnet@v5.3.0
         with:
           global-json-file: PowerShell/global.json
+
+      - name: Download PowerShell apphosts
+        uses: actions/download-artifact@v7.0.1
+        with:
+          pattern: PowerShell-SDK-AppHost-*
+          path: apphost-download
+          merge-multiple: false
 
       - name: Install Mono
         run: |
@@ -84,6 +195,37 @@ jobs:
           Copy-Item "./nupkg-prod/*.png" ./nupkg-out/ -Force
           Remove-Item ./nupkg-out/contentFiles/any/any/ref -Recurse -Force -ErrorAction SilentlyContinue
           Copy-Item ./nupkg-prod/contentFiles/any/any/ref ./nupkg-out/contentFiles/any/any/ref -Recurse
+
+          $AppHostDownloadPath = (Resolve-Path ../apphost-download).Path
+          $AppHostPackageRoot = "./nupkg-out/tools/apphost"
+          New-Item $AppHostPackageRoot -ItemType Directory -Force | Out-Null
+          $AppHostFilesByRid = [ordered]@{
+            'win-x64' = @('pwsh.exe', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+            'linux-x64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+            'linux-arm64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+            'osx-x64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+            'osx-arm64' = @('pwsh', 'pwsh.dll', 'pwsh.runtimeconfig.json')
+          }
+          foreach ($Rid in $AppHostFilesByRid.Keys) {
+            $ArtifactPath = Join-Path $AppHostDownloadPath "PowerShell-SDK-AppHost-$Rid"
+            if (-not (Test-Path $ArtifactPath -PathType Container)) {
+              throw "Missing PowerShell apphost artifact for $Rid at $ArtifactPath"
+            }
+
+            $DestinationPath = Join-Path $AppHostPackageRoot $Rid
+            New-Item $DestinationPath -ItemType Directory -Force | Out-Null
+            foreach ($FileName in $AppHostFilesByRid[$Rid]) {
+              $SourcePath = Join-Path $ArtifactPath $FileName
+              if (-not (Test-Path $SourcePath -PathType Leaf)) {
+                throw "Missing required PowerShell apphost file for $Rid`: $SourcePath"
+              }
+              Copy-Item $SourcePath $DestinationPath -Force
+            }
+          }
+
+          New-Item "./nupkg-out/buildTransitive" -ItemType Directory -Force | Out-Null
+          Copy-Item "../eng/Microsoft.PowerShell.SDK.targets" "./nupkg-out/buildTransitive/Microsoft.PowerShell.SDK.targets" -Force
+
           New-Item "./package" -ItemType Directory -Force | Out-Null
           Push-Location ./nupkg-out
           nuget pack

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 
 | Workflow | Purpose | Output |
 | --- | --- | --- |
-| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source and repacks `Microsoft.PowerShell.SDK` for the upstream target framework, including opt-in apphost import files. | `PowerShell-SDK-7.6.3` artifact containing a `.nupkg`. |
+| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, repacks `Microsoft.PowerShell.SDK` for the upstream target framework, and validates the package in a sample .NET app with opt-in apphost import. | `PowerShell-SDK-7.6.3` artifact containing a `.nupkg`. |
 | `.github/workflows/powershell.yml` | Builds self-contained PowerShell archives for Windows, macOS, and Linux on x64 and arm64. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
 | `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 
 | Workflow | Purpose | Output |
 | --- | --- | --- |
-| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source and repacks `Microsoft.PowerShell.SDK` for the upstream target framework. | `PowerShell-SDK-7.6.3` artifact containing a `.nupkg`. |
+| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source and repacks `Microsoft.PowerShell.SDK` for the upstream target framework, including opt-in apphost import files. | `PowerShell-SDK-7.6.3` artifact containing a `.nupkg`. |
 | `.github/workflows/powershell.yml` | Builds self-contained PowerShell archives for Windows, macOS, and Linux on x64 and arm64. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
 | `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
 
@@ -26,5 +26,15 @@ All workflows are manual and can be started from the GitHub Actions **Run workfl
 ## Notes
 
 The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from the locally built SDK binaries plus metadata, reference assemblies, and content layout from the official NuGet package for the same PowerShell version.
+
+The SDK package also includes source-built apphost files for `win-x64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project can copy the matching `pwsh`/`pwsh.exe`, `pwsh.dll`, and `pwsh.runtimeconfig.json` into its output by setting:
+
+```xml
+<PropertyGroup>
+  <PowerShellSDKIncludeAppHost>true</PowerShellSDKIncludeAppHost>
+</PropertyGroup>
+```
+
+The package selects `$(RuntimeIdentifier)` first, then falls back to the SDK host runtime identifier. Set `PowerShellSDKAppHostRuntimeIdentifier` to override that selection explicitly. Unsupported runtime identifiers fail the build with a clear error instead of silently omitting apphost files.
 
 Generated source checkouts and build artifacts are not part of this repository.

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -1,0 +1,59 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PowerShellSDKIncludeAppHost Condition="'$(PowerShellSDKIncludeAppHost)' == ''">false</PowerShellSDKIncludeAppHost>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+    <_PowerShellSDKAppHostRid Condition="'$(PowerShellSDKAppHostRuntimeIdentifier)' != ''">$(PowerShellSDKAppHostRuntimeIdentifier)</_PowerShellSDKAppHostRid>
+    <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_PowerShellSDKAppHostRid>
+    <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == '' and '$(NETCoreSdkRuntimeIdentifier)' != ''">$(NETCoreSdkRuntimeIdentifier)</_PowerShellSDKAppHostRid>
+    <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == 'win7-x64'">win-x64</_PowerShellSDKAppHostRid>
+  </PropertyGroup>
+
+  <Target Name="_PowerShellSDKResolveAppHost"
+          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+    <Error Condition="'$(_PowerShellSDKAppHostRid)' == ''"
+           Text="PowerShellSDKIncludeAppHost is true, but no runtime identifier is available. Set RuntimeIdentifier or PowerShellSDKAppHostRuntimeIdentifier." />
+
+    <PropertyGroup>
+      <_PowerShellSDKAppHostSourceDir>$(MSBuildThisFileDirectory)../tools/apphost/$(_PowerShellSDKAppHostRid)/</_PowerShellSDKAppHostSourceDir>
+    </PropertyGroup>
+
+    <Error Condition="!Exists('$(_PowerShellSDKAppHostSourceDir)')"
+           Text="PowerShellSDKIncludeAppHost is true, but Microsoft.PowerShell.SDK does not include apphost files for '$(_PowerShellSDKAppHostRid)'. Set PowerShellSDKAppHostRuntimeIdentifier to a supported runtime identifier." />
+
+    <ItemGroup>
+      <_PowerShellSDKAppHostFile Include="$(_PowerShellSDKAppHostSourceDir)**/*" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PowerShellSDKCopyAppHostToOutput"
+          DependsOnTargets="_PowerShellSDKResolveAppHost"
+          AfterTargets="CopyFilesToOutputDirectory"
+          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+    <Copy SourceFiles="@(_PowerShellSDKAppHostFile)"
+          DestinationFiles="@(_PowerShellSDKAppHostFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+    <Exec Command="chmod +x &quot;$(OutDir)pwsh&quot;"
+          Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)pwsh')" />
+  </Target>
+
+  <Target Name="PowerShellSDKAddAppHostToPublish"
+          DependsOnTargets="_PowerShellSDKResolveAppHost"
+          BeforeTargets="ComputeFilesToPublish"
+          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKAppHostFile)">
+        <RelativePath>%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PowerShellSDKChmodPublishedAppHost"
+          AfterTargets="Publish"
+          Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
+    <Exec Command="chmod +x &quot;$(PublishDir)pwsh&quot;"
+          Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)pwsh')" />
+  </Target>
+</Project>

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -1,0 +1,209 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string] $PackageDirectory,
+
+  [Parameter(Mandatory)]
+  [string] $PowerShellVersion,
+
+  [Parameter(Mandatory)]
+  [string] $TargetFramework,
+
+  [string] $RuntimeIdentifier
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Get-DefaultRuntimeIdentifier {
+  $Architecture = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
+    'X64' { 'x64'; break }
+    'Arm64' { 'arm64'; break }
+    default { throw "Unsupported architecture for PowerShell SDK apphost validation: $_" }
+  }
+
+  if ($IsWindows) {
+    return "win-$Architecture"
+  }
+  if ($IsLinux) {
+    return "linux-$Architecture"
+  }
+  if ($IsMacOS) {
+    return "osx-$Architecture"
+  }
+
+  throw "Unsupported operating system for PowerShell SDK apphost validation"
+}
+
+function Invoke-DotNet {
+  param(
+    [Parameter(Mandatory)]
+    [string[]] $Arguments
+  )
+
+  & dotnet @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Add-ProjectProperty {
+  param(
+    [Parameter(Mandatory)]
+    [xml] $Project,
+
+    [Parameter(Mandatory)]
+    [System.Xml.XmlElement] $PropertyGroup,
+
+    [Parameter(Mandatory)]
+    [string] $Name,
+
+    [Parameter(Mandatory)]
+    [string] $Value
+  )
+
+  $Element = $Project.CreateElement($Name)
+  $Element.InnerText = $Value
+  [void] $PropertyGroup.AppendChild($Element)
+}
+
+if (-not $RuntimeIdentifier) {
+  $RuntimeIdentifier = Get-DefaultRuntimeIdentifier
+}
+
+$PackageDirectoryPath = (Resolve-Path -LiteralPath $PackageDirectory).Path
+$Package = Get-ChildItem -LiteralPath $PackageDirectoryPath -Filter "Microsoft.PowerShell.SDK.$PowerShellVersion*.nupkg" |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+if (-not $Package) {
+  throw "Unable to find Microsoft.PowerShell.SDK.$PowerShellVersion nupkg in $PackageDirectoryPath"
+}
+
+$ExecutableName = if ($RuntimeIdentifier -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
+$ExpectedPackageEntries = @(
+  'buildTransitive/Microsoft.PowerShell.SDK.targets',
+  "tools/apphost/$RuntimeIdentifier/$ExecutableName",
+  "tools/apphost/$RuntimeIdentifier/pwsh.dll",
+  "tools/apphost/$RuntimeIdentifier/pwsh.runtimeconfig.json"
+)
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$Zip = [System.IO.Compression.ZipFile]::OpenRead($Package.FullName)
+try {
+  foreach ($EntryName in $ExpectedPackageEntries) {
+    if (-not ($Zip.Entries | Where-Object FullName -EQ $EntryName)) {
+      throw "SDK package is missing expected entry: $EntryName"
+    }
+  }
+} finally {
+  $Zip.Dispose()
+}
+
+$TempRoot = if ($Env:RUNNER_TEMP) { $Env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$ValidationRoot = Join-Path $TempRoot "powershell-sdk-validation-$([Guid]::NewGuid().ToString('N'))"
+$SampleDirectory = Join-Path $ValidationRoot 'sample'
+$PackagesDirectory = Join-Path $ValidationRoot 'packages'
+
+New-Item $SampleDirectory -ItemType Directory -Force | Out-Null
+New-Item $PackagesDirectory -ItemType Directory -Force | Out-Null
+
+$PreviousNuGetPackages = $Env:NUGET_PACKAGES
+$Env:NUGET_PACKAGES = $PackagesDirectory
+$PreviousLocation = Get-Location
+
+try {
+  Push-Location $SampleDirectory
+
+  Invoke-DotNet @('new', 'console', '--framework', $TargetFramework, '--no-restore')
+  $ProjectPath = (Get-ChildItem -LiteralPath $SampleDirectory -Filter '*.csproj' | Select-Object -First 1).FullName
+  if (-not $ProjectPath) {
+    throw "No sample project was generated in $SampleDirectory"
+  }
+
+  $EscapedPackageDirectoryPath = [System.Security.SecurityElement]::Escape($PackageDirectoryPath)
+  $NuGetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="ci-nupkg" value="$EscapedPackageDirectoryPath" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="ci-nupkg">
+      <package pattern="Microsoft.PowerShell.SDK" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+"@
+  Set-Content -Path (Join-Path $SampleDirectory 'nuget.config') -Value $NuGetConfig -Encoding utf8
+
+  $Program = @'
+using System;
+using System.Management.Automation;
+
+using PowerShell ps = PowerShell.Create();
+ps.AddScript("$PSVersionTable.PSVersion.ToString()");
+foreach (PSObject result in ps.Invoke())
+{
+    Console.WriteLine(result);
+}
+'@
+  Set-Content -Path (Join-Path $SampleDirectory 'Program.cs') -Value $Program -Encoding utf8
+
+  [xml] $Project = Get-Content -LiteralPath $ProjectPath
+  $PropertyGroup = @($Project.Project.PropertyGroup)[0]
+  Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'RuntimeIdentifier' -Value $RuntimeIdentifier
+  Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKIncludeAppHost' -Value 'true'
+  $Project.Save($ProjectPath)
+
+  Invoke-DotNet @('add', $ProjectPath, 'package', 'Microsoft.PowerShell.SDK', '--version', $PowerShellVersion, '--no-restore')
+  Invoke-DotNet @('restore', $ProjectPath, '--configfile', (Join-Path $SampleDirectory 'nuget.config'), '--verbosity', 'minimal')
+
+  $RestoredSdkPath = Join-Path $PackagesDirectory (Join-Path 'microsoft.powershell.sdk' $PowerShellVersion)
+  foreach ($RelativePath in $ExpectedPackageEntries) {
+    $RestoredPath = Join-Path $RestoredSdkPath ($RelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path $RestoredPath -PathType Leaf)) {
+      throw "Restored SDK package is missing expected file: $RestoredPath"
+    }
+  }
+
+  Invoke-DotNet @('build', $ProjectPath, '--no-restore', '--nologo', '--verbosity', 'minimal')
+
+  $OutputDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Debug' (Join-Path $TargetFramework $RuntimeIdentifier)))
+  $PwshPath = Join-Path $OutputDirectory $ExecutableName
+  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json')) {
+    $OutputPath = Join-Path $OutputDirectory $FileName
+    if (-not (Test-Path $OutputPath -PathType Leaf)) {
+      throw "Sample app output is missing expected apphost file: $OutputPath"
+    }
+  }
+
+  $AppOutput = & dotnet run --project $ProjectPath --no-build
+  if ($LASTEXITCODE -ne 0) {
+    throw "Sample app failed with exit code $LASTEXITCODE"
+  }
+  $AppVersion = [string] ($AppOutput | Select-Object -Last 1)
+  if ($AppVersion.Trim() -ne $PowerShellVersion) {
+    throw "Sample app imported PowerShell SDK version '$AppVersion', expected '$PowerShellVersion'"
+  }
+
+  $PwshOutput = & $PwshPath -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+  if ($LASTEXITCODE -ne 0) {
+    throw "$PwshPath failed with exit code $LASTEXITCODE"
+  }
+  $PwshVersion = [string] ($PwshOutput | Select-Object -Last 1)
+  if ($PwshVersion.Trim() -ne $PowerShellVersion) {
+    throw "$PwshPath reported PowerShell version '$PwshVersion', expected '$PowerShellVersion'"
+  }
+
+  Write-Host "Validated Microsoft.PowerShell.SDK $PowerShellVersion from $($Package.FullName)"
+  Write-Host "Sample app imported PowerShell SDK $($AppVersion.Trim())"
+  Write-Host "Sample output apphost reported PowerShell $($PwshVersion.Trim()): $PwshPath"
+} finally {
+  Set-Location $PreviousLocation
+  $Env:NUGET_PACKAGES = $PreviousNuGetPackages
+}


### PR DESCRIPTION
## Summary
- Add source-built apphost files to the repacked `Microsoft.PowerShell.SDK` package for Windows, Linux, and macOS.
- Add an opt-in `PowerShellSDKIncludeAppHost` MSBuild target that copies the matching `pwsh`/`pwsh.exe`, `pwsh.dll`, and `pwsh.runtimeconfig.json` to consumer build and publish output.
- Add CI validation that restores the generated SDK package into a sample .NET app, imports the SDK, builds with apphost import enabled, and runs `pwsh` from the sample app output.

## Validation
- Parsed `.github/workflows/powershell-sdk.yml` with a YAML parser.
- Parsed `eng/Validate-PowerShellSdkPackage.ps1` with the PowerShell parser.
- Ran `git diff --check`.
- Ran the sample validation script locally against a CI-produced SDK nupkg.
- PowerShell SDK workflow succeeded on this branch: https://github.com/awakecoding/pwsh-distro/actions/runs/27793566957
- CI validation step logged:
  - `Validated Microsoft.PowerShell.SDK 7.6.3`
  - `Sample app imported PowerShell SDK 7.6.3`
  - `Sample output apphost reported PowerShell 7.6.3`
