### PR TITLE
Vendor PowerShell SDK package

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -3,6 +3,8 @@ on: workflow_dispatch
 env:
   POWERSHELL_VERSION: "7.6.3"
   POWERSHELL_REF: "v7.6.3"
+  SDK_VENDOR_NAME: "Devolutions"
+  SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
 jobs:
   apphost:
     name: PowerShell SDK apphost [${{matrix.rid}}]
@@ -90,6 +92,69 @@ jobs:
 
           Start-PSBuild @PSBuildParams
 
+          $PackageRuntimeGroup = switch ($Rid) {
+            'win-x64' { 'win'; break }
+            'linux-x64' { 'unix'; break }
+            default { $null }
+          }
+          if ($PackageRuntimeGroup) {
+            [xml]$CommonProps = Get-Content ./PowerShell.Common.props
+            $TargetFramework = $CommonProps.Project.PropertyGroup |
+              ForEach-Object { $_.TargetFramework } |
+              Where-Object { $_ } |
+              Select-Object -First 1
+            if (-not $TargetFramework) {
+              throw "Unable to determine PowerShell TargetFramework from PowerShell.Common.props"
+            }
+
+            dotnet build ./src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj -c Release /p:ReleaseTag=$Env:POWERSHELL_VERSION
+            if ($LASTEXITCODE -ne 0) {
+              throw "Building Microsoft.PowerShell.SDK failed with exit code $LASTEXITCODE"
+            }
+
+            $SdkBinPath = "./src/Microsoft.PowerShell.SDK/bin/Release/$TargetFramework"
+            $PackageRuntimePath = Join-Path (Join-Path $PWD "package-runtime") $Rid
+            New-Item $PackageRuntimePath -ItemType Directory -Force | Out-Null
+            $PackageRuntimeAssemblies = if ($PackageRuntimeGroup -eq 'win') {
+              @(
+                'Microsoft.PowerShell.SDK',
+                'System.Management.Automation',
+                'Microsoft.PowerShell.Commands.Management',
+                'Microsoft.PowerShell.Commands.Utility',
+                'Microsoft.PowerShell.ConsoleHost',
+                'Microsoft.PowerShell.Security',
+                'Microsoft.PowerShell.Commands.Diagnostics',
+                'Microsoft.Management.Infrastructure.CimCmdlets',
+                'Microsoft.WSMan.Management',
+                'Microsoft.PowerShell.CoreCLR.Eventing',
+                'Microsoft.WSMan.Runtime'
+              )
+            } else {
+              @(
+                'Microsoft.PowerShell.SDK',
+                'System.Management.Automation',
+                'Microsoft.PowerShell.Commands.Management',
+                'Microsoft.PowerShell.Commands.Utility',
+                'Microsoft.PowerShell.ConsoleHost',
+                'Microsoft.PowerShell.Security'
+              )
+            }
+
+            foreach ($AssemblyName in $PackageRuntimeAssemblies) {
+              $SourceDirectory = if ($AssemblyName -eq 'Microsoft.PowerShell.SDK') { $SdkBinPath } else { $OutputPath }
+              $AssemblyPath = Join-Path $SourceDirectory "$AssemblyName.dll"
+              if (-not (Test-Path $AssemblyPath -PathType Leaf)) {
+                throw "PowerShell build did not produce package runtime assembly: $AssemblyPath"
+              }
+              Copy-Item $AssemblyPath $PackageRuntimePath -Force
+
+              $XmlPath = Join-Path $SourceDirectory "$AssemblyName.xml"
+              if (Test-Path $XmlPath -PathType Leaf) {
+                Copy-Item $XmlPath $PackageRuntimePath -Force
+              }
+            }
+          }
+
           $StagePath = Join-Path (Join-Path $PWD "apphost-package") $Rid
           New-Item $StagePath -ItemType Directory -Force | Out-Null
           $RequiredFiles = @("${{matrix.executable}}", "pwsh.dll", "pwsh.runtimeconfig.json")
@@ -106,6 +171,13 @@ jobs:
         with:
           name: PowerShell-SDK-AppHost-${{matrix.rid}}
           path: PowerShell/apphost-package/${{matrix.rid}}/*
+
+      - name: Upload package runtime libraries
+        if: ${{ matrix.rid == 'win-x64' || matrix.rid == 'linux-x64' }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: PowerShell-SDK-PackageRuntime-${{matrix.rid}}
+          path: PowerShell/package-runtime/${{matrix.rid}}/*
 
   build:
     name: PowerShell SDK [7.6.3]
@@ -133,6 +205,13 @@ jobs:
         with:
           pattern: PowerShell-SDK-AppHost-*
           path: apphost-download
+          merge-multiple: false
+
+      - name: Download package runtime libraries
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: PowerShell-SDK-PackageRuntime-*
+          path: package-runtime-download
           merge-multiple: false
 
       - name: Install Mono
@@ -164,16 +243,159 @@ jobs:
 
           $SdkBinPath = "./src/Microsoft.PowerShell.SDK/bin/Release/$TargetFramework"
           dotnet build ./src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj -c Release /p:ReleaseTag=$Env:POWERSHELL_VERSION
+          if ($LASTEXITCODE -ne 0) {
+            throw "Building Microsoft.PowerShell.SDK failed with exit code $LASTEXITCODE"
+          }
 
-          Remove-Item .\nupkg-out -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-          New-Item .\nupkg-out -ItemType Directory -Force
-          New-Item "./nupkg-out/unix/lib/$TargetFramework" -ItemType Directory | Out-Null
-          New-Item "./nupkg-out/ref/$TargetFramework" -ItemType Directory | Out-Null
-          Copy-Item "$SdkBinPath/Microsoft.PowerShell.SDK*.dll" "./nupkg-out/unix/lib/$TargetFramework"
-          Copy-Item "$SdkBinPath/Microsoft.PowerShell.SDK*.xml" "./nupkg-out/unix/lib/$TargetFramework"
-          Copy-Item "$SdkBinPath/*.dll" "./nupkg-out/ref/$TargetFramework"
-          Copy-Item "$SdkBinPath/*.xml" "./nupkg-out/ref/$TargetFramework"
-          $AnyAnyRuntimesDir = "./nupkg-out/contentFiles/any/any/runtimes"
+          function Add-OverlayFile {
+            param(
+              [Parameter(Mandatory)]
+              [hashtable] $OverlayPathMap,
+
+              [Parameter(Mandatory)]
+              [string] $PackageRelativePath,
+
+              [Parameter(Mandatory)]
+              [string] $SourcePath,
+
+              [bool] $Required = $true
+            )
+
+            if (Test-Path $SourcePath -PathType Leaf) {
+              $OverlayPathMap[$PackageRelativePath] = $SourcePath
+              return
+            }
+
+            if ($Required) {
+              throw "Missing source-built package file for $PackageRelativePath`: $SourcePath"
+            }
+          }
+
+          function Pack-VendoredPackage {
+            param(
+              [Parameter(Mandatory)]
+              [string] $PackageStagePath,
+
+              [Parameter(Mandatory)]
+              [string] $PackageOutputPath
+            )
+
+            Push-Location $PackageStagePath
+            try {
+              nuget pack -OutputDirectory $PackageOutputPath -NonInteractive
+              if ($LASTEXITCODE -ne 0) {
+                throw "nuget pack failed for $PackageStagePath with exit code $LASTEXITCODE"
+              }
+            } finally {
+              Pop-Location
+            }
+          }
+
+          $PackageOutputPath = Join-Path $PWD "package"
+          $PackageStageRoot = Join-Path $PWD "nupkg-stage"
+          Remove-Item $PackageOutputPath -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $PackageStageRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item $PackageOutputPath -ItemType Directory -Force | Out-Null
+          New-Item $PackageStageRoot -ItemType Directory -Force | Out-Null
+
+          $PackageRuntimeDownloadPath = (Resolve-Path ../package-runtime-download).Path
+          $PackageRuntimeRoots = @{
+            'unix' = Join-Path $PackageRuntimeDownloadPath 'PowerShell-SDK-PackageRuntime-linux-x64';
+            'win' = Join-Path $PackageRuntimeDownloadPath 'PowerShell-SDK-PackageRuntime-win-x64';
+          }
+          foreach ($RuntimeGroup in $PackageRuntimeRoots.Keys) {
+            if (-not (Test-Path $PackageRuntimeRoots[$RuntimeGroup] -PathType Container)) {
+              throw "Missing package runtime artifact for $RuntimeGroup at $($PackageRuntimeRoots[$RuntimeGroup])"
+            }
+          }
+
+          $EmbeddedAssemblyDefinitions = @(
+            @{
+              AssemblyName = 'System.Management.Automation';
+              ProjectDirectory = 'System.Management.Automation';
+              RuntimeGroups = @('unix', 'win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.Commands.Management';
+              ProjectDirectory = 'Microsoft.PowerShell.Commands.Management';
+              RuntimeGroups = @('unix', 'win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.Commands.Utility';
+              ProjectDirectory = 'Microsoft.PowerShell.Commands.Utility';
+              RuntimeGroups = @('unix', 'win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.ConsoleHost';
+              ProjectDirectory = 'Microsoft.PowerShell.ConsoleHost';
+              RuntimeGroups = @('unix', 'win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.Security';
+              ProjectDirectory = 'Microsoft.PowerShell.Security';
+              RuntimeGroups = @('unix', 'win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.Commands.Diagnostics';
+              ProjectDirectory = 'Microsoft.PowerShell.Commands.Diagnostics';
+              RuntimeGroups = @('win');
+            },
+            @{
+              AssemblyName = 'Microsoft.Management.Infrastructure.CimCmdlets';
+              ProjectDirectory = 'Microsoft.Management.Infrastructure.CimCmdlets';
+              RuntimeGroups = @('win');
+            },
+            @{
+              AssemblyName = 'Microsoft.WSMan.Management';
+              ProjectDirectory = 'Microsoft.WSMan.Management';
+              RuntimeGroups = @('win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.CoreCLR.Eventing';
+              ProjectDirectory = 'Microsoft.PowerShell.CoreCLR.Eventing';
+              RuntimeGroups = @('win');
+            },
+            @{
+              AssemblyName = 'Microsoft.WSMan.Runtime';
+              ProjectDirectory = 'Microsoft.WSMan.Runtime';
+              RuntimeGroups = @('win');
+            },
+            @{
+              AssemblyName = 'Microsoft.PowerShell.SDK';
+              ProjectDirectory = 'Microsoft.PowerShell.SDK';
+              RuntimeGroups = @('unix', 'win');
+            }
+          )
+
+          $SdkStagePath = Join-Path $PackageStageRoot $Env:SDK_PACKAGE_ID
+          $SdkOverlayPathMap = @{}
+          foreach ($AssemblyDefinition in $EmbeddedAssemblyDefinitions) {
+            $AssemblyName = $AssemblyDefinition.AssemblyName
+            $LocalAssemblyPath = "./src/$($AssemblyDefinition.ProjectDirectory)/bin/Release/$TargetFramework"
+            $RefSourcePath = Join-Path $LocalAssemblyPath "$AssemblyName.dll"
+            if (-not (Test-Path $RefSourcePath -PathType Leaf)) {
+              $RefSourcePath = Join-Path $PackageRuntimeRoots['win'] "$AssemblyName.dll"
+            }
+
+            Add-OverlayFile $SdkOverlayPathMap "ref/$TargetFramework/$AssemblyName.dll" $RefSourcePath
+            $RefXmlPath = [System.IO.Path]::ChangeExtension($RefSourcePath, '.xml')
+            Add-OverlayFile $SdkOverlayPathMap "ref/$TargetFramework/$AssemblyName.xml" $RefXmlPath $false
+
+            foreach ($RuntimeGroup in $AssemblyDefinition.RuntimeGroups) {
+              $RuntimeSourceRoot = if ($RuntimeGroup -eq 'unix') { $LocalAssemblyPath } else { $PackageRuntimeRoots[$RuntimeGroup] }
+              Add-OverlayFile $SdkOverlayPathMap "runtimes/$RuntimeGroup/lib/$TargetFramework/$AssemblyName.dll" (Join-Path $RuntimeSourceRoot "$AssemblyName.dll")
+            }
+          }
+
+          ../eng/Vendor-PowerShellSdkPackage.ps1 `
+            -PackageRoot $SdkStagePath `
+            -PowerShellVersion $Env:POWERSHELL_VERSION `
+            -PackageId $Env:SDK_PACKAGE_ID `
+            -VendorName $Env:SDK_VENDOR_NAME `
+            -OverlayPathMap $SdkOverlayPathMap
+
+          $AnyAnyRuntimesDir = Join-Path $SdkStagePath "contentFiles/any/any/runtimes"
+          Remove-Item $AnyAnyRuntimesDir -Recurse -Force -ErrorAction SilentlyContinue
           New-Item $AnyAnyRuntimesDir -ItemType Directory | Out-Null
           Get-Item ./src/Modules/Unix/*/*.ps* | ForEach-Object {
             $ModuleName = Split-Path (Split-Path $_.FullName -Parent) -Leaf
@@ -187,18 +409,9 @@ jobs:
             New-Item $DestinationDir -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
             Copy-Item $_ $DestinationDir
           }
-          $PSVersion = $Env:POWERSHELL_VERSION
-          Invoke-WebRequest "https://www.nuget.org/api/v2/package/Microsoft.PowerShell.SDK/$PSVersion" -OutFile "Microsoft.PowerShell.SDK.${PSVersion}.nupkg"
-          Remove-Item ./nupkg-prod -Recurse -Force -ErrorAction SilentlyContinue
-          Expand-Archive "./Microsoft.PowerShell.SDK.${PSVersion}.nupkg" nupkg-prod
-          Get-ChildItem -Path ./nupkg-prod -Include @('*.nuspec','*.png','*.xml') -Recurse -Depth 1 | % { Copy-Item $_ ./nupkg-out -Force }
-          Copy-Item "./nupkg-prod/*.nuspec" ./nupkg-out/ -Force
-          Copy-Item "./nupkg-prod/*.png" ./nupkg-out/ -Force
-          Remove-Item ./nupkg-out/contentFiles/any/any/ref -Recurse -Force -ErrorAction SilentlyContinue
-          Copy-Item ./nupkg-prod/contentFiles/any/any/ref ./nupkg-out/contentFiles/any/any/ref -Recurse
 
           $AppHostDownloadPath = (Resolve-Path ../apphost-download).Path
-          $AppHostPackageRoot = "./nupkg-out/tools/apphost"
+          $AppHostPackageRoot = Join-Path $SdkStagePath "tools/apphost"
           New-Item $AppHostPackageRoot -ItemType Directory -Force | Out-Null
           $AppHostFilesByRid = [ordered]@{
             'win-x64' = @('pwsh.exe', 'pwsh.dll', 'pwsh.runtimeconfig.json')
@@ -224,14 +437,11 @@ jobs:
             }
           }
 
-          New-Item "./nupkg-out/buildTransitive" -ItemType Directory -Force | Out-Null
-          Copy-Item "../eng/Microsoft.PowerShell.SDK.targets" "./nupkg-out/buildTransitive/Microsoft.PowerShell.SDK.targets" -Force
+          $BuildTransitivePath = Join-Path $SdkStagePath "buildTransitive"
+          New-Item $BuildTransitivePath -ItemType Directory -Force | Out-Null
+          Copy-Item "../eng/Microsoft.PowerShell.SDK.targets" (Join-Path $BuildTransitivePath "$Env:SDK_PACKAGE_ID.targets") -Force
 
-          New-Item "./package" -ItemType Directory -Force | Out-Null
-          Push-Location ./nupkg-out
-          nuget pack
-          Move-Item *.nupkg ../package
-          Pop-Location
+          Pack-VendoredPackage $SdkStagePath $PackageOutputPath
 
       - name: Validate PowerShell SDK package
         shell: pwsh
@@ -241,7 +451,9 @@ jobs:
             -PackageDirectory ./PowerShell/package `
             -PowerShellVersion $Env:POWERSHELL_VERSION `
             -TargetFramework $Env:POWERSHELL_TARGET_FRAMEWORK `
-            -RuntimeIdentifier linux-x64
+            -RuntimeIdentifier linux-x64 `
+            -PackageId $Env:SDK_PACKAGE_ID `
+            -PackageVendorName $Env:SDK_VENDOR_NAME
 
       - name: Upload PowerShell package
         uses: actions/upload-artifact@v7.0.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pwsh-distro
 
-GitHub Actions workflows for building redistributable PowerShell artifacts from upstream source. The primary target is a refreshed `Microsoft.PowerShell.SDK` package, and the secondary target is a self-contained PowerShell distribution archive.
+GitHub Actions workflows for building redistributable PowerShell artifacts from upstream source. The primary target is a single vendored `Devolutions.PowerShell.SDK` package, and the secondary target is a self-contained PowerShell distribution archive.
 
 ## Current pins
 
@@ -8,6 +8,7 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 | --- | --- |
 | PowerShell | `7.6.3` / `v7.6.3` |
 | PowerShell target framework | `net10.0` |
+| PowerShell SDK package ID | `Devolutions.PowerShell.SDK` |
 | .NET runtime workflow | `v10.0.5` |
 | llvm-prebuilt | `v2026.1.1` |
 | clang+llvm | `22.1.4` |
@@ -17,7 +18,7 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 
 | Workflow | Purpose | Output |
 | --- | --- | --- |
-| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, repacks `Microsoft.PowerShell.SDK` for the upstream target framework, and validates the package in a sample .NET app with opt-in apphost import. | `PowerShell-SDK-7.6.3` artifact containing a `.nupkg`. |
+| `.github/workflows/powershell-sdk.yml` | Builds PowerShell from source, vendors the source-built PowerShell SDK assemblies into one `Devolutions.PowerShell.SDK` package, and validates it in a sample .NET app with opt-in apphost import. | `PowerShell-SDK-7.6.3` artifact containing one `.nupkg`. |
 | `.github/workflows/powershell.yml` | Builds self-contained PowerShell archives for Windows, macOS, and Linux on x64 and arm64. | `PowerShell-7.6.3-<os>-<arch>` `.tar.gz` artifacts. |
 | `.github/workflows/dotnet-runtime.yml` | Builds the .NET runtime tag used by this PowerShell release for Windows, macOS, and Linux on x86_64 and arm64 with prebuilt clang+llvm from `awakecoding/llvm-prebuilt`. | Runtime build output in the workflow logs/workspace. |
 
@@ -25,9 +26,11 @@ All workflows are manual and can be started from the GitHub Actions **Run workfl
 
 ## Notes
 
-The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from the locally built SDK binaries plus metadata, reference assemblies, and content layout from the official NuGet package for the same PowerShell version.
+The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from locally built PowerShell binaries plus package layouts from the official NuGet packages for the same PowerShell version, then `eng/Vendor-PowerShellSdkPackage.ps1` rewrites the NuGet package ID and vendor metadata to Devolutions.
 
-The SDK package also includes source-built apphost files for `win-x64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project can copy the matching `pwsh`/`pwsh.exe`, `pwsh.dll`, and `pwsh.runtimeconfig.json` into its output by setting:
+The package keeps original assembly identities (`System.Management.Automation.dll`, `Microsoft.PowerShell.Commands.Utility.dll`, and related assemblies) so consumers only need to change the NuGet package reference. Source-built PowerShell assemblies are embedded directly in `Devolutions.PowerShell.SDK`, so validation fails if original source-built package IDs such as `Microsoft.PowerShell.SDK` or `System.Management.Automation` appear in the restore graph. External packages that are not built by this repository, including `Microsoft.PowerShell.Native` and `Microsoft.PowerShell.MarkdownRender`, remain normal public NuGet dependencies.
+
+The SDK package also includes source-built apphost files for `win-x64`, `linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64`. These files are inert by default. A consuming project can copy the matching `pwsh`/`pwsh.exe`, `pwsh.dll`, `pwsh.runtimeconfig.json`, and the matching built-in module manifests into its output by setting:
 
 ```xml
 <PropertyGroup>
@@ -35,6 +38,6 @@ The SDK package also includes source-built apphost files for `win-x64`, `linux-x
 </PropertyGroup>
 ```
 
-The package selects `$(RuntimeIdentifier)` first, then falls back to the SDK host runtime identifier. Set `PowerShellSDKAppHostRuntimeIdentifier` to override that selection explicitly. Unsupported runtime identifiers fail the build with a clear error instead of silently omitting apphost files.
+The package selects `$(RuntimeIdentifier)` first, then falls back to the SDK host runtime identifier. Set `PowerShellSDKAppHostRuntimeIdentifier` to override that selection explicitly. Unsupported runtime identifiers fail the build with a clear error instead of silently omitting apphost files. The apphost output is intended for running scripts with the core built-in modules from `$PSHOME/Modules`; it is not a full PowerShell distribution archive with localized resources, help content, or optional gallery modules.
 
 Generated source checkouts and build artifacts are not part of this repository.

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -8,6 +8,8 @@
     <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_PowerShellSDKAppHostRid>
     <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == '' and '$(NETCoreSdkRuntimeIdentifier)' != ''">$(NETCoreSdkRuntimeIdentifier)</_PowerShellSDKAppHostRid>
     <_PowerShellSDKAppHostRid Condition="'$(_PowerShellSDKAppHostRid)' == 'win7-x64'">win-x64</_PowerShellSDKAppHostRid>
+    <_PowerShellSDKAppHostRuntimeGroup>unix</_PowerShellSDKAppHostRuntimeGroup>
+    <_PowerShellSDKAppHostRuntimeGroup Condition="$([System.String]::Copy('$(_PowerShellSDKAppHostRid)').StartsWith('win'))">win</_PowerShellSDKAppHostRuntimeGroup>
   </PropertyGroup>
 
   <Target Name="_PowerShellSDKResolveAppHost"
@@ -17,13 +19,17 @@
 
     <PropertyGroup>
       <_PowerShellSDKAppHostSourceDir>$(MSBuildThisFileDirectory)../tools/apphost/$(_PowerShellSDKAppHostRid)/</_PowerShellSDKAppHostSourceDir>
+      <_PowerShellSDKModuleSourceDir>$(MSBuildThisFileDirectory)../contentFiles/any/any/runtimes/$(_PowerShellSDKAppHostRuntimeGroup)/lib/$(TargetFramework)/Modules/</_PowerShellSDKModuleSourceDir>
     </PropertyGroup>
 
     <Error Condition="!Exists('$(_PowerShellSDKAppHostSourceDir)')"
-           Text="PowerShellSDKIncludeAppHost is true, but Microsoft.PowerShell.SDK does not include apphost files for '$(_PowerShellSDKAppHostRid)'. Set PowerShellSDKAppHostRuntimeIdentifier to a supported runtime identifier." />
+           Text="PowerShellSDKIncludeAppHost is true, but this PowerShell SDK package does not include apphost files for '$(_PowerShellSDKAppHostRid)'. Set PowerShellSDKAppHostRuntimeIdentifier to a supported runtime identifier." />
+    <Error Condition="!Exists('$(_PowerShellSDKModuleSourceDir)')"
+           Text="PowerShellSDKIncludeAppHost is true, but this PowerShell SDK package does not include module files for runtime group '$(_PowerShellSDKAppHostRuntimeGroup)' and target framework '$(TargetFramework)'." />
 
     <ItemGroup>
       <_PowerShellSDKAppHostFile Include="$(_PowerShellSDKAppHostSourceDir)**/*" />
+      <_PowerShellSDKModuleFile Include="$(_PowerShellSDKModuleSourceDir)**/*" />
     </ItemGroup>
   </Target>
 
@@ -33,6 +39,9 @@
           Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
     <Copy SourceFiles="@(_PowerShellSDKAppHostFile)"
           DestinationFiles="@(_PowerShellSDKAppHostFile->'$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_PowerShellSDKModuleFile)"
+          DestinationFiles="@(_PowerShellSDKModuleFile->'$(OutDir)Modules/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
     <Exec Command="chmod +x &quot;$(OutDir)pwsh&quot;"
           Condition="'$(OS)' != 'Windows_NT' and Exists('$(OutDir)pwsh')" />
@@ -45,6 +54,10 @@
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_PowerShellSDKAppHostFile)">
         <RelativePath>%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_PowerShellSDKModuleFile)">
+        <RelativePath>Modules/%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
     </ItemGroup>

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -9,7 +9,11 @@ param(
   [Parameter(Mandatory)]
   [string] $TargetFramework,
 
-  [string] $RuntimeIdentifier
+  [string] $RuntimeIdentifier,
+
+  [string] $PackageId = 'Devolutions.PowerShell.SDK',
+
+  [string] $PackageVendorName = 'Devolutions'
 )
 
 Set-StrictMode -Version 3.0
@@ -67,25 +71,101 @@ function Add-ProjectProperty {
   [void] $PropertyGroup.AppendChild($Element)
 }
 
+function Read-ZipEntryText {
+  param(
+    [Parameter(Mandatory)]
+    [System.IO.Compression.ZipArchiveEntry] $Entry
+  )
+
+  $Stream = $Entry.Open()
+  $Reader = [System.IO.StreamReader]::new($Stream)
+  try {
+    return $Reader.ReadToEnd()
+  } finally {
+    $Reader.Dispose()
+    $Stream.Dispose()
+  }
+}
+
+function Get-NuspecMetadataValue {
+  param(
+    [Parameter(Mandatory)]
+    [xml] $Nuspec,
+
+    [Parameter(Mandatory)]
+    [System.Xml.XmlNamespaceManager] $NamespaceManager,
+
+    [Parameter(Mandatory)]
+    [string] $Name
+  )
+
+  $Element = $Nuspec.SelectSingleNode("/n:package/n:metadata/n:$Name", $NamespaceManager)
+  if (-not $Element) {
+    throw "SDK package nuspec is missing required metadata element '$Name'"
+  }
+
+  return $Element.InnerText
+}
+
 if (-not $RuntimeIdentifier) {
   $RuntimeIdentifier = Get-DefaultRuntimeIdentifier
 }
 
 $PackageDirectoryPath = (Resolve-Path -LiteralPath $PackageDirectory).Path
-$Package = Get-ChildItem -LiteralPath $PackageDirectoryPath -Filter "Microsoft.PowerShell.SDK.$PowerShellVersion*.nupkg" |
+$Package = Get-ChildItem -LiteralPath $PackageDirectoryPath -Filter "$PackageId.$PowerShellVersion*.nupkg" |
   Sort-Object LastWriteTime -Descending |
   Select-Object -First 1
 if (-not $Package) {
-  throw "Unable to find Microsoft.PowerShell.SDK.$PowerShellVersion nupkg in $PackageDirectoryPath"
+  throw "Unable to find $PackageId.$PowerShellVersion nupkg in $PackageDirectoryPath"
 }
 
+$EmbeddedPowerShellPackageIds = @(
+  'Microsoft.PowerShell.SDK',
+  'System.Management.Automation',
+  'Microsoft.PowerShell.Commands.Management',
+  'Microsoft.PowerShell.Commands.Utility',
+  'Microsoft.PowerShell.ConsoleHost',
+  'Microsoft.PowerShell.Security',
+  'Microsoft.PowerShell.Commands.Diagnostics',
+  'Microsoft.Management.Infrastructure.CimCmdlets',
+  'Microsoft.WSMan.Management',
+  'Microsoft.PowerShell.CoreCLR.Eventing',
+  'Microsoft.WSMan.Runtime'
+)
+
 $ExecutableName = if ($RuntimeIdentifier -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
+$RuntimeAssetGroup = if ($RuntimeIdentifier -like 'win-*') { 'win' } else { 'unix' }
 $ExpectedPackageEntries = @(
-  'buildTransitive/Microsoft.PowerShell.SDK.targets',
+  "buildTransitive/$PackageId.targets",
   "tools/apphost/$RuntimeIdentifier/$ExecutableName",
   "tools/apphost/$RuntimeIdentifier/pwsh.dll",
-  "tools/apphost/$RuntimeIdentifier/pwsh.runtimeconfig.json"
+  "tools/apphost/$RuntimeIdentifier/pwsh.runtimeconfig.json",
+  "ref/$TargetFramework/System.Management.Automation.dll",
+  "ref/$TargetFramework/Microsoft.PowerShell.Commands.Management.dll",
+  "ref/$TargetFramework/Microsoft.PowerShell.Commands.Utility.dll",
+  "ref/$TargetFramework/Microsoft.PowerShell.ConsoleHost.dll",
+  "ref/$TargetFramework/Microsoft.PowerShell.Security.dll",
+  "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.SDK.dll",
+  "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/System.Management.Automation.dll",
+  "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.Commands.Management.dll",
+  "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.Commands.Utility.dll",
+  "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.ConsoleHost.dll",
+  "runtimes/$RuntimeAssetGroup/lib/$TargetFramework/Microsoft.PowerShell.Security.dll"
 )
+if ($RuntimeAssetGroup -eq 'win') {
+  $ExpectedPackageEntries += @(
+    "ref/$TargetFramework/Microsoft.PowerShell.Commands.Diagnostics.dll",
+    "ref/$TargetFramework/Microsoft.Management.Infrastructure.CimCmdlets.dll",
+    "ref/$TargetFramework/Microsoft.WSMan.Management.dll",
+    "ref/$TargetFramework/Microsoft.PowerShell.CoreCLR.Eventing.dll",
+    "ref/$TargetFramework/Microsoft.WSMan.Runtime.dll",
+    "runtimes/win/lib/$TargetFramework/Microsoft.PowerShell.Commands.Diagnostics.dll",
+    "runtimes/win/lib/$TargetFramework/Microsoft.Management.Infrastructure.CimCmdlets.dll",
+    "runtimes/win/lib/$TargetFramework/Microsoft.WSMan.Management.dll",
+    "runtimes/win/lib/$TargetFramework/Microsoft.PowerShell.CoreCLR.Eventing.dll",
+    "runtimes/win/lib/$TargetFramework/Microsoft.WSMan.Runtime.dll"
+  )
+}
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $Zip = [System.IO.Compression.ZipFile]::OpenRead($Package.FullName)
@@ -93,6 +173,43 @@ try {
   foreach ($EntryName in $ExpectedPackageEntries) {
     if (-not ($Zip.Entries | Where-Object FullName -EQ $EntryName)) {
       throw "SDK package is missing expected entry: $EntryName"
+    }
+  }
+
+  if ($PackageVendorName) {
+    $NuspecEntry = $Zip.Entries |
+      Where-Object { $_.FullName -like '*.nuspec' -and $_.FullName -notlike '*/*' } |
+      Select-Object -First 1
+    if (-not $NuspecEntry) {
+      throw "SDK package is missing a root nuspec"
+    }
+
+    [xml] $Nuspec = Read-ZipEntryText -Entry $NuspecEntry
+    $NamespaceManager = [System.Xml.XmlNamespaceManager]::new($Nuspec.NameTable)
+    $NamespaceManager.AddNamespace('n', $Nuspec.DocumentElement.NamespaceURI)
+
+    $NuspecPackageId = Get-NuspecMetadataValue -Nuspec $Nuspec -NamespaceManager $NamespaceManager -Name 'id'
+    if ($NuspecPackageId -ne $PackageId) {
+      throw "SDK package nuspec id is '$NuspecPackageId', expected '$PackageId'"
+    }
+
+    foreach ($ElementName in @('authors', 'owners', 'copyright')) {
+      $Value = Get-NuspecMetadataValue -Nuspec $Nuspec -NamespaceManager $NamespaceManager -Name $ElementName
+      if ($Value -notlike "*$PackageVendorName*") {
+        throw "SDK package nuspec metadata '$ElementName' does not contain '$PackageVendorName': $Value"
+      }
+      if ($PackageVendorName -ne 'Microsoft' -and $Value -like '*Microsoft*') {
+        throw "SDK package nuspec metadata '$ElementName' still contains 'Microsoft': $Value"
+      }
+    }
+
+    $OriginalDependencies = @(
+      $Nuspec.SelectNodes('/n:package/n:metadata/n:dependencies//n:dependency', $NamespaceManager) |
+        Where-Object { $EmbeddedPowerShellPackageIds -contains [string] $_.id } |
+        ForEach-Object { [string] $_.id }
+    )
+    if ($OriginalDependencies) {
+      throw "SDK package nuspec still references original PowerShell package dependencies: $($OriginalDependencies -join ', ')"
     }
   }
 } finally {
@@ -131,7 +248,7 @@ try {
   </packageSources>
   <packageSourceMapping>
     <packageSource key="ci-nupkg">
-      <package pattern="Microsoft.PowerShell.SDK" />
+      <package pattern="$PackageId" />
     </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />
@@ -160,10 +277,25 @@ foreach (PSObject result in ps.Invoke())
   Add-ProjectProperty -Project $Project -PropertyGroup $PropertyGroup -Name 'PowerShellSDKIncludeAppHost' -Value 'true'
   $Project.Save($ProjectPath)
 
-  Invoke-DotNet @('add', $ProjectPath, 'package', 'Microsoft.PowerShell.SDK', '--version', $PowerShellVersion, '--no-restore')
+  Invoke-DotNet @('add', $ProjectPath, 'package', $PackageId, '--version', $PowerShellVersion, '--no-restore')
   Invoke-DotNet @('restore', $ProjectPath, '--configfile', (Join-Path $SampleDirectory 'nuget.config'), '--verbosity', 'minimal')
 
-  $RestoredSdkPath = Join-Path $PackagesDirectory (Join-Path 'microsoft.powershell.sdk' $PowerShellVersion)
+  $AssetsPath = Join-Path (Split-Path $ProjectPath -Parent) 'obj/project.assets.json'
+  $Assets = Get-Content -LiteralPath $AssetsPath -Raw | ConvertFrom-Json
+  $RestoredPackageIds = @(
+    $Assets.libraries.PSObject.Properties.Name |
+      ForEach-Object { ($_ -split '/', 2)[0] }
+  )
+  $RestoredOriginalPowerShellPackageIds = @(
+    $RestoredPackageIds |
+      Where-Object { $EmbeddedPowerShellPackageIds -contains $_ }
+  )
+  if ($RestoredOriginalPowerShellPackageIds) {
+    throw "Restore imported original PowerShell package IDs instead of vendored IDs: $($RestoredOriginalPowerShellPackageIds -join ', ')"
+  }
+
+  $RestoredSdkPackageDirectoryName = $PackageId.ToLowerInvariant()
+  $RestoredSdkPath = Join-Path $PackagesDirectory (Join-Path $RestoredSdkPackageDirectoryName $PowerShellVersion)
   foreach ($RelativePath in $ExpectedPackageEntries) {
     $RestoredPath = Join-Path $RestoredSdkPath ($RelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
     if (-not (Test-Path $RestoredPath -PathType Leaf)) {
@@ -181,6 +313,15 @@ foreach (PSObject result in ps.Invoke())
       throw "Sample app output is missing expected apphost file: $OutputPath"
     }
   }
+  foreach ($RelativeModulePath in @(
+      'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1',
+      'Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1',
+      'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1')) {
+    $OutputPath = Join-Path $OutputDirectory ($RelativeModulePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path $OutputPath -PathType Leaf)) {
+      throw "Sample app output is missing expected apphost module file: $OutputPath"
+    }
+  }
 
   $AppOutput = & dotnet run --project $ProjectPath --no-build
   if ($LASTEXITCODE -ne 0) {
@@ -191,18 +332,76 @@ foreach (PSObject result in ps.Invoke())
     throw "Sample app imported PowerShell SDK version '$AppVersion', expected '$PowerShellVersion'"
   }
 
-  $PwshOutput = & $PwshPath -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+  Invoke-DotNet @('publish', $ProjectPath, '--nologo', '--verbosity', 'minimal', '-c', 'Release', '-r', $RuntimeIdentifier, '--self-contained', 'true')
+
+  $PublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $TargetFramework (Join-Path $RuntimeIdentifier 'publish'))))
+  $PublishedPwshPath = Join-Path $PublishDirectory $ExecutableName
+  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json')) {
+    $PublishedPath = Join-Path $PublishDirectory $FileName
+    if (-not (Test-Path $PublishedPath -PathType Leaf)) {
+      throw "Sample publish output is missing expected apphost file: $PublishedPath"
+    }
+  }
+  foreach ($RelativeModulePath in @(
+      'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1',
+      'Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1',
+      'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1')) {
+    $PublishedPath = Join-Path $PublishDirectory ($RelativeModulePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path $PublishedPath -PathType Leaf)) {
+      throw "Sample publish output is missing expected apphost module file: $PublishedPath"
+    }
+  }
+
+  $PwshOutput = & $PublishedPwshPath -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
   if ($LASTEXITCODE -ne 0) {
-    throw "$PwshPath failed with exit code $LASTEXITCODE"
+    throw "$PublishedPwshPath failed with exit code $LASTEXITCODE"
   }
   $PwshVersion = [string] ($PwshOutput | Select-Object -Last 1)
   if ($PwshVersion.Trim() -ne $PowerShellVersion) {
-    throw "$PwshPath reported PowerShell version '$PwshVersion', expected '$PowerShellVersion'"
+    throw "$PublishedPwshPath reported PowerShell version '$PwshVersion', expected '$PowerShellVersion'"
   }
 
-  Write-Host "Validated Microsoft.PowerShell.SDK $PowerShellVersion from $($Package.FullName)"
-  Write-Host "Sample app imported PowerShell SDK $($AppVersion.Trim())"
-  Write-Host "Sample output apphost reported PowerShell $($PwshVersion.Trim()): $PwshPath"
+  $PreviousPSModulePath = $Env:PSModulePath
+  $PreviousExpectedModuleRoot = $Env:PowerShellSDKExpectedModuleRoot
+  try {
+    $Env:PSModulePath = ''
+    $Env:PowerShellSDKExpectedModuleRoot = Join-Path $PublishDirectory 'Modules'
+    $ModuleProbe = @'
+$ErrorActionPreference = 'Stop'
+$expectedModuleRoot = $env:PowerShellSDKExpectedModuleRoot
+foreach ($moduleName in 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility') {
+  $module = Get-Module -ListAvailable $moduleName | Select-Object -First 1
+  if ($null -eq $module) {
+    throw "Module '$moduleName' is not available"
+  }
+
+  if (-not $module.Path.StartsWith($expectedModuleRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Module '$moduleName' was loaded from '$($module.Path)' instead of '$expectedModuleRoot'"
+  }
+}
+
+$getProcess = Get-Command Get-Process -ErrorAction Stop
+if ($getProcess.Source -ne 'Microsoft.PowerShell.Management') {
+  throw "Get-Process resolved from '$($getProcess.Source)' instead of Microsoft.PowerShell.Management"
+}
+
+$selectObject = Get-Command Select-Object -ErrorAction Stop
+if ($selectObject.Source -ne 'Microsoft.PowerShell.Utility') {
+  throw "Select-Object resolved from '$($selectObject.Source)' instead of Microsoft.PowerShell.Utility"
+}
+'@
+    $PwshModuleProbeOutput = & $PublishedPwshPath -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $ModuleProbe
+    if ($LASTEXITCODE -ne 0) {
+      throw "$PublishedPwshPath failed module probe with exit code $LASTEXITCODE"
+    }
+  } finally {
+    $Env:PSModulePath = $PreviousPSModulePath
+    $Env:PowerShellSDKExpectedModuleRoot = $PreviousExpectedModuleRoot
+  }
+
+  Write-Host "Validated $PackageId $PowerShellVersion from $($Package.FullName)"
+  Write-Host "Sample app imported vendored PowerShell SDK $($AppVersion.Trim())"
+  Write-Host "Sample publish apphost reported PowerShell $($PwshVersion.Trim()): $PublishedPwshPath"
 } finally {
   Set-Location $PreviousLocation
   $Env:NUGET_PACKAGES = $PreviousNuGetPackages

--- a/eng/Vendor-PowerShellSdkPackage.ps1
+++ b/eng/Vendor-PowerShellSdkPackage.ps1
@@ -1,0 +1,424 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string] $PackageRoot,
+
+  [Parameter(Mandatory)]
+  [string] $PowerShellVersion,
+
+  [string] $PackageId = 'Devolutions.PowerShell.SDK',
+
+  [string] $VendorName = 'Devolutions',
+
+  [string] $OriginalVendorName = 'Microsoft',
+
+  [hashtable] $OverlayPathMap,
+
+  [string] $SourcePackageDirectory
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$OriginalPackageId = 'Microsoft.PowerShell.SDK'
+$EmbeddedPackageIds = @(
+  'Microsoft.PowerShell.SDK',
+  'System.Management.Automation',
+  'Microsoft.PowerShell.Commands.Management',
+  'Microsoft.PowerShell.Commands.Utility',
+  'Microsoft.PowerShell.ConsoleHost',
+  'Microsoft.PowerShell.Security',
+  'Microsoft.PowerShell.Commands.Diagnostics',
+  'Microsoft.Management.Infrastructure.CimCmdlets',
+  'Microsoft.WSMan.Management',
+  'Microsoft.PowerShell.CoreCLR.Eventing',
+  'Microsoft.WSMan.Runtime'
+)
+
+function Get-PackageSourcePath {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Id,
+
+    [Parameter(Mandatory)]
+    [string] $Version,
+
+    [Parameter(Mandatory)]
+    [string] $DestinationDirectory,
+
+    [string] $LocalPackageDirectory
+  )
+
+  if ($LocalPackageDirectory) {
+    $LocalPackage = Get-ChildItem -LiteralPath $LocalPackageDirectory -Filter "$Id.$Version*.nupkg" -File |
+      Sort-Object LastWriteTime -Descending |
+      Select-Object -First 1
+    if ($LocalPackage) {
+      return $LocalPackage.FullName
+    }
+  }
+
+  $PackagePath = Join-Path $DestinationDirectory "$Id.$Version.nupkg"
+  Invoke-WebRequest "https://www.nuget.org/api/v2/package/$Id/$Version" -OutFile $PackagePath
+  return $PackagePath
+}
+
+function Expand-Package {
+  param(
+    [Parameter(Mandatory)]
+    [string] $PackagePath,
+
+    [Parameter(Mandatory)]
+    [string] $DestinationPath
+  )
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $DestinationPath)
+}
+
+function Copy-PackagePayload {
+  param(
+    [Parameter(Mandatory)]
+    [string] $SourceRoot,
+
+    [Parameter(Mandatory)]
+    [string] $DestinationRoot
+  )
+
+  $ExcludedRootItems = @('[Content_Types].xml', '_rels', 'package', '.signature.p7s')
+  Get-ChildItem -LiteralPath $SourceRoot -Force |
+    Where-Object { $ExcludedRootItems -notcontains $_.Name } |
+    ForEach-Object {
+      Copy-Item -LiteralPath $_.FullName -Destination $DestinationRoot -Recurse -Force
+    }
+}
+
+function Get-NuspecPath {
+  param(
+    [Parameter(Mandatory)]
+    [string] $PackageRootPath
+  )
+
+  $NuspecFiles = @(Get-ChildItem -LiteralPath $PackageRootPath -Filter '*.nuspec' -File)
+  if ($NuspecFiles.Count -ne 1) {
+    throw "Expected exactly one nuspec in '$PackageRootPath', found $($NuspecFiles.Count)"
+  }
+
+  return $NuspecFiles[0].FullName
+}
+
+function Get-NuspecMetadataElement {
+  param(
+    [Parameter(Mandatory)]
+    [xml] $Document,
+
+    [Parameter(Mandatory)]
+    [System.Xml.XmlNamespaceManager] $NamespaceManager,
+
+    [Parameter(Mandatory)]
+    [string] $Name
+  )
+
+  $Element = $Document.SelectSingleNode("/n:package/n:metadata/n:$Name", $NamespaceManager)
+  if (-not $Element) {
+    throw "The package nuspec is missing required metadata element '$Name'"
+  }
+
+  return [System.Xml.XmlElement] $Element
+}
+
+function Set-NuspecMetadataText {
+  param(
+    [Parameter(Mandatory)]
+    [xml] $Document,
+
+    [Parameter(Mandatory)]
+    [System.Xml.XmlNamespaceManager] $NamespaceManager,
+
+    [Parameter(Mandatory)]
+    [string] $Name,
+
+    [Parameter(Mandatory)]
+    [string] $Value
+  )
+
+  $Element = $Document.SelectSingleNode("/n:package/n:metadata/n:$Name", $NamespaceManager)
+  if (-not $Element) {
+    $Metadata = $Document.SelectSingleNode('/n:package/n:metadata', $NamespaceManager)
+    if (-not $Metadata) {
+      throw "The package nuspec is missing metadata"
+    }
+
+    $Element = $Document.CreateElement($Name, $Document.DocumentElement.NamespaceURI)
+    [void] $Metadata.AppendChild($Element)
+  }
+
+  $Element.InnerText = $Value
+}
+
+function Compare-PackageVersion {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Left,
+
+    [Parameter(Mandatory)]
+    [string] $Right
+  )
+
+  try {
+    return [version]::Parse($Left).CompareTo([version]::Parse($Right))
+  } catch {
+    return [string]::CompareOrdinal($Left, $Right)
+  }
+}
+
+function Add-DependencyRecord {
+  param(
+    [Parameter(Mandatory)]
+    [System.Collections.Specialized.OrderedDictionary] $DependencyGroups,
+
+    [AllowEmptyString()]
+    [string] $TargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $Id,
+
+    [Parameter(Mandatory)]
+    [string] $Version
+  )
+
+  if (-not $DependencyGroups.Contains($TargetFramework)) {
+    $DependencyGroups[$TargetFramework] = [ordered]@{}
+  }
+
+  $Dependencies = $DependencyGroups[$TargetFramework]
+  if (-not $Dependencies.Contains($Id) -or (Compare-PackageVersion -Left $Version -Right $Dependencies[$Id]) -gt 0) {
+    $Dependencies[$Id] = $Version
+  }
+}
+
+function Add-ExternalDependenciesFromNuspec {
+  param(
+    [Parameter(Mandatory)]
+    [string] $NuspecPath,
+
+    [Parameter(Mandatory)]
+    [string[]] $EmbeddedIds,
+
+    [Parameter(Mandatory)]
+    [System.Collections.Specialized.OrderedDictionary] $DependencyGroups
+  )
+
+  [xml] $Nuspec = Get-Content -LiteralPath $NuspecPath
+  $NamespaceManager = [System.Xml.XmlNamespaceManager]::new($Nuspec.NameTable)
+  $NamespaceManager.AddNamespace('n', $Nuspec.DocumentElement.NamespaceURI)
+
+  $DependencyGroupNodes = @($Nuspec.SelectNodes('/n:package/n:metadata/n:dependencies/n:group', $NamespaceManager))
+  foreach ($Group in $DependencyGroupNodes) {
+    $TargetFramework = [string] $Group.targetFramework
+    foreach ($Dependency in @($Group.SelectNodes('n:dependency', $NamespaceManager))) {
+      $DependencyId = [string] $Dependency.id
+      if ($EmbeddedIds -contains $DependencyId) {
+        continue
+      }
+
+      Add-DependencyRecord `
+        -DependencyGroups $DependencyGroups `
+        -TargetFramework $TargetFramework `
+        -Id $DependencyId `
+        -Version ([string] $Dependency.version)
+    }
+  }
+
+  foreach ($Dependency in @($Nuspec.SelectNodes('/n:package/n:metadata/n:dependencies/n:dependency', $NamespaceManager))) {
+    $DependencyId = [string] $Dependency.id
+    if ($EmbeddedIds -contains $DependencyId) {
+      continue
+    }
+
+    Add-DependencyRecord `
+      -DependencyGroups $DependencyGroups `
+      -TargetFramework '' `
+      -Id $DependencyId `
+      -Version ([string] $Dependency.version)
+  }
+}
+
+function Set-NuspecDependencies {
+  param(
+    [Parameter(Mandatory)]
+    [xml] $Document,
+
+    [Parameter(Mandatory)]
+    [System.Xml.XmlNamespaceManager] $NamespaceManager,
+
+    [Parameter(Mandatory)]
+    [System.Collections.Specialized.OrderedDictionary] $DependencyGroups
+  )
+
+  $Metadata = $Document.SelectSingleNode('/n:package/n:metadata', $NamespaceManager)
+  if (-not $Metadata) {
+    throw "The package nuspec is missing metadata"
+  }
+
+  $Dependencies = $Document.SelectSingleNode('/n:package/n:metadata/n:dependencies', $NamespaceManager)
+  if (-not $Dependencies) {
+    $Dependencies = $Document.CreateElement('dependencies', $Document.DocumentElement.NamespaceURI)
+    [void] $Metadata.AppendChild($Dependencies)
+  }
+
+  $Dependencies.RemoveAll()
+
+  foreach ($TargetFramework in @($DependencyGroups.Keys | Sort-Object)) {
+    $Group = $Document.CreateElement('group', $Document.DocumentElement.NamespaceURI)
+    if ($TargetFramework) {
+      $TargetFrameworkAttribute = $Document.CreateAttribute('targetFramework')
+      $TargetFrameworkAttribute.Value = $TargetFramework
+      [void] $Group.Attributes.Append($TargetFrameworkAttribute)
+    }
+
+    $GroupDependencies = $DependencyGroups[$TargetFramework]
+    foreach ($DependencyId in @($GroupDependencies.Keys | Sort-Object)) {
+      $Dependency = $Document.CreateElement('dependency', $Document.DocumentElement.NamespaceURI)
+
+      $IdAttribute = $Document.CreateAttribute('id')
+      $IdAttribute.Value = $DependencyId
+      [void] $Dependency.Attributes.Append($IdAttribute)
+
+      $VersionAttribute = $Document.CreateAttribute('version')
+      $VersionAttribute.Value = $GroupDependencies[$DependencyId]
+      [void] $Dependency.Attributes.Append($VersionAttribute)
+
+      [void] $Group.AppendChild($Dependency)
+    }
+
+    [void] $Dependencies.AppendChild($Group)
+  }
+}
+
+function Update-SdkNuspec {
+  param(
+    [Parameter(Mandatory)]
+    [string] $NuspecPath,
+
+    [Parameter(Mandatory)]
+    [string] $NewPackageId,
+
+    [Parameter(Mandatory)]
+    [string] $Vendor,
+
+    [Parameter(Mandatory)]
+    [string] $OriginalVendor,
+
+    [Parameter(Mandatory)]
+    [System.Collections.Specialized.OrderedDictionary] $DependencyGroups
+  )
+
+  [xml] $Nuspec = Get-Content -LiteralPath $NuspecPath
+  $NamespaceManager = [System.Xml.XmlNamespaceManager]::new($Nuspec.NameTable)
+  $NamespaceManager.AddNamespace('n', $Nuspec.DocumentElement.NamespaceURI)
+
+  $Id = Get-NuspecMetadataElement -Document $Nuspec -NamespaceManager $NamespaceManager -Name 'id'
+  if ($Id.InnerText -ne $OriginalPackageId -and $Id.InnerText -ne $NewPackageId) {
+    throw "Expected SDK nuspec package id '$OriginalPackageId' or '$NewPackageId', found '$($Id.InnerText)'"
+  }
+
+  $Id.InnerText = $NewPackageId
+  Set-NuspecMetadataText -Document $Nuspec -NamespaceManager $NamespaceManager -Name 'authors' -Value $Vendor
+  Set-NuspecMetadataText -Document $Nuspec -NamespaceManager $NamespaceManager -Name 'owners' -Value $Vendor
+
+  $Copyright = $Nuspec.SelectSingleNode('/n:package/n:metadata/n:copyright', $NamespaceManager)
+  if ($Copyright) {
+    $Copyright.InnerText = $Copyright.InnerText.Replace("$OriginalVendor Corporation", $Vendor).Replace($OriginalVendor, $Vendor)
+  }
+
+  Set-NuspecDependencies -Document $Nuspec -NamespaceManager $NamespaceManager -DependencyGroups $DependencyGroups
+
+  $WriterSettings = [System.Xml.XmlWriterSettings]::new()
+  $WriterSettings.Encoding = [System.Text.UTF8Encoding]::new($false)
+  $WriterSettings.Indent = $true
+
+  $Writer = [System.Xml.XmlWriter]::Create($NuspecPath, $WriterSettings)
+  try {
+    $Nuspec.Save($Writer)
+  } finally {
+    $Writer.Dispose()
+  }
+}
+
+function Copy-OverlayFiles {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Root,
+
+    [Parameter(Mandatory)]
+    [hashtable] $PathMap
+  )
+
+  foreach ($PackageRelativePath in $PathMap.Keys) {
+    $SourcePath = (Resolve-Path -LiteralPath $PathMap[$PackageRelativePath]).Path
+    if (-not (Test-Path $SourcePath -PathType Leaf)) {
+      throw "Overlay source file does not exist: $SourcePath"
+    }
+
+    $DestinationPath = Join-Path $Root ($PackageRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    $DestinationDirectory = Split-Path $DestinationPath -Parent
+    New-Item $DestinationDirectory -ItemType Directory -Force | Out-Null
+    Copy-Item -LiteralPath $SourcePath -Destination $DestinationPath -Force
+  }
+}
+
+$PackageRootPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PackageRoot)
+$TempRoot = if ($Env:RUNNER_TEMP) { $Env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$WorkDirectory = Join-Path $TempRoot "powershell-sdk-vendor-$([Guid]::NewGuid().ToString('N'))"
+$PackageCacheDirectory = Join-Path $WorkDirectory 'packages'
+$ExtractedPackagesDirectory = Join-Path $WorkDirectory 'extracted'
+$DependencyGroups = [System.Collections.Specialized.OrderedDictionary]::new()
+
+Remove-Item $PackageRootPath -Recurse -Force -ErrorAction SilentlyContinue
+New-Item $PackageRootPath -ItemType Directory -Force | Out-Null
+New-Item $PackageCacheDirectory, $ExtractedPackagesDirectory -ItemType Directory -Force | Out-Null
+
+try {
+  $ExtractedPackageRoots = @{}
+
+  foreach ($EmbeddedPackageId in $EmbeddedPackageIds) {
+    $PackagePath = Get-PackageSourcePath `
+      -Id $EmbeddedPackageId `
+      -Version $PowerShellVersion `
+      -DestinationDirectory $PackageCacheDirectory `
+      -LocalPackageDirectory $SourcePackageDirectory
+
+    $ExtractedPackagePath = Join-Path $ExtractedPackagesDirectory $EmbeddedPackageId
+    Expand-Package -PackagePath $PackagePath -DestinationPath $ExtractedPackagePath
+    $ExtractedPackageRoots[$EmbeddedPackageId] = $ExtractedPackagePath
+
+    Add-ExternalDependenciesFromNuspec `
+      -NuspecPath (Get-NuspecPath -PackageRootPath $ExtractedPackagePath) `
+      -EmbeddedIds $EmbeddedPackageIds `
+      -DependencyGroups $DependencyGroups
+  }
+
+  Copy-PackagePayload -SourceRoot $ExtractedPackageRoots[$OriginalPackageId] -DestinationRoot $PackageRootPath
+
+  $OriginalNuspecPath = Get-NuspecPath -PackageRootPath $PackageRootPath
+  $VendoredNuspecPath = Join-Path $PackageRootPath "$PackageId.nuspec"
+  if ($OriginalNuspecPath -ne $VendoredNuspecPath) {
+    Move-Item -LiteralPath $OriginalNuspecPath -Destination $VendoredNuspecPath -Force
+  }
+
+  Update-SdkNuspec `
+    -NuspecPath $VendoredNuspecPath `
+    -NewPackageId $PackageId `
+    -Vendor $VendorName `
+    -OriginalVendor $OriginalVendorName `
+    -DependencyGroups $DependencyGroups
+
+  if ($OverlayPathMap) {
+    Copy-OverlayFiles -Root $PackageRootPath -PathMap $OverlayPathMap
+  }
+
+  Write-Host "Vendored $OriginalPackageId $PowerShellVersion as $PackageId with embedded PowerShell assemblies"
+} finally {
+  Remove-Item $WorkDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- build a single `Devolutions.PowerShell.SDK` package with source-built PowerShell assemblies embedded directly
- keep original assembly identities while removing source-built PowerShell package dependencies from the restore graph
- copy apphost files plus built-in module manifests for minimal `pwsh` publish outputs
- strengthen validation for restore/import/apphost/module resolution behavior

## Validation
- PowerShell parser checks
- MSBuild targets XML parse
- workflow YAML parse
- `git diff --check`
- local SDK/package validation
- code-review pass