### PR TITLE
Add PowerShell downstream patch branch model with same-repo submodule

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -2,7 +2,10 @@ name: PowerShell SDK
 on: workflow_dispatch
 env:
   POWERSHELL_VERSION: "7.6.3"
-  POWERSHELL_REF: "v7.6.3"
+  POWERSHELL_RELEASE_TAG: "v7.6.3"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.3"
+  POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
+  POWERSHELL_SOURCE_REF: "release/v7.6.3"
   SDK_VENDOR_NAME: "Devolutions"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
   MULTI_PWSH_APPHOST_PACKAGE_ID: "Devolutions.MultiPwsh.Cli"
@@ -41,12 +44,65 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v7.0.0
 
-      - name: Clone PowerShell ${{env.POWERSHELL_VERSION}}
+      - name: Clone PowerShell source ${{env.POWERSHELL_SOURCE_REF}}
         uses: actions/checkout@v7.0.0
         with:
-          repository: PowerShell/PowerShell
-          ref: ${{env.POWERSHELL_REF}}
+          repository: ${{env.POWERSHELL_SOURCE_REPOSITORY}}
+          ref: ${{env.POWERSHELL_SOURCE_REF}}
           path: PowerShell
+          fetch-depth: 0
+
+      - name: Verify PowerShell source ref
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Invoke-GitPowerShell {
+            param(
+              [Parameter(Mandatory, ValueFromRemainingArguments)]
+              [string[]] $Arguments
+            )
+
+            $Output = & git -C PowerShell @Arguments
+            if ($LASTEXITCODE -ne 0) {
+              throw "git -C PowerShell $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+            }
+
+            return $Output
+          }
+
+          function Test-GitCommitRef {
+            param(
+              [Parameter(Mandatory)]
+              [string] $Ref
+            )
+
+            & git -C PowerShell rev-parse --verify "$Ref^{commit}" *> $null
+            return $LASTEXITCODE -eq 0
+          }
+
+          $ExpectedVersion = $Env:POWERSHELL_RELEASE_TAG -replace '^v', ''
+          if ($Env:POWERSHELL_VERSION -ne $ExpectedVersion) {
+            throw "POWERSHELL_VERSION '$Env:POWERSHELL_VERSION' does not match POWERSHELL_RELEASE_TAG '$Env:POWERSHELL_RELEASE_TAG'."
+          }
+
+          $SourceCommit = (Invoke-GitPowerShell rev-parse HEAD).Trim()
+          Write-Host "PowerShell source: $Env:POWERSHELL_SOURCE_REPOSITORY@$Env:POWERSHELL_SOURCE_REF ($SourceCommit)"
+
+          $BaseRef = if ($Env:POWERSHELL_SOURCE_REPOSITORY -eq $Env:GITHUB_REPOSITORY) {
+            $Env:POWERSHELL_UPSTREAM_TAG
+          } else {
+            $Env:POWERSHELL_RELEASE_TAG
+          }
+
+          if (-not (Test-GitCommitRef $BaseRef)) {
+            throw "Expected PowerShell base tag '$BaseRef' was not found in the PowerShell checkout."
+          }
+
+          & git -C PowerShell merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw "PowerShell source ref '$Env:POWERSHELL_SOURCE_REF' is not based on '$BaseRef'."
+          }
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0
@@ -268,7 +324,7 @@ jobs:
             Runtime = "${{matrix.psbuild-runtime}}";
             Output = $OutputPath;
             Clean = $true;
-            ReleaseTag = $Env:POWERSHELL_REF;
+            ReleaseTag = $Env:POWERSHELL_RELEASE_TAG;
             NoPSModuleRestore = $true;
             SkipExperimentalFeatureGeneration = $true;
           }
@@ -388,12 +444,65 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v7.0.0
 
-      - name: Clone PowerShell ${{env.POWERSHELL_VERSION}}
+      - name: Clone PowerShell source ${{env.POWERSHELL_SOURCE_REF}}
         uses: actions/checkout@v7.0.0
         with:
-          repository: PowerShell/PowerShell
-          ref: ${{env.POWERSHELL_REF}}
+          repository: ${{env.POWERSHELL_SOURCE_REPOSITORY}}
+          ref: ${{env.POWERSHELL_SOURCE_REF}}
           path: PowerShell
+          fetch-depth: 0
+
+      - name: Verify PowerShell source ref
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Invoke-GitPowerShell {
+            param(
+              [Parameter(Mandatory, ValueFromRemainingArguments)]
+              [string[]] $Arguments
+            )
+
+            $Output = & git -C PowerShell @Arguments
+            if ($LASTEXITCODE -ne 0) {
+              throw "git -C PowerShell $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+            }
+
+            return $Output
+          }
+
+          function Test-GitCommitRef {
+            param(
+              [Parameter(Mandatory)]
+              [string] $Ref
+            )
+
+            & git -C PowerShell rev-parse --verify "$Ref^{commit}" *> $null
+            return $LASTEXITCODE -eq 0
+          }
+
+          $ExpectedVersion = $Env:POWERSHELL_RELEASE_TAG -replace '^v', ''
+          if ($Env:POWERSHELL_VERSION -ne $ExpectedVersion) {
+            throw "POWERSHELL_VERSION '$Env:POWERSHELL_VERSION' does not match POWERSHELL_RELEASE_TAG '$Env:POWERSHELL_RELEASE_TAG'."
+          }
+
+          $SourceCommit = (Invoke-GitPowerShell rev-parse HEAD).Trim()
+          Write-Host "PowerShell source: $Env:POWERSHELL_SOURCE_REPOSITORY@$Env:POWERSHELL_SOURCE_REF ($SourceCommit)"
+
+          $BaseRef = if ($Env:POWERSHELL_SOURCE_REPOSITORY -eq $Env:GITHUB_REPOSITORY) {
+            $Env:POWERSHELL_UPSTREAM_TAG
+          } else {
+            $Env:POWERSHELL_RELEASE_TAG
+          }
+
+          if (-not (Test-GitCommitRef $BaseRef)) {
+            throw "Expected PowerShell base tag '$BaseRef' was not found in the PowerShell checkout."
+          }
+
+          & git -C PowerShell merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw "PowerShell source ref '$Env:POWERSHELL_SOURCE_REF' is not based on '$BaseRef'."
+          }
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0
@@ -429,7 +538,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Import-Module .\build.psm1 -Force
           Start-PSBootstrap -Scenario DotNet
-          Start-PSBuild -Clean -PSModuleRestore -Configuration Release -ReleaseTag $Env:POWERSHELL_REF -UseNuGetOrg
+          Start-PSBuild -Clean -PSModuleRestore -Configuration Release -ReleaseTag $Env:POWERSHELL_RELEASE_TAG -UseNuGetOrg
 
           [xml]$CommonProps = Get-Content ./PowerShell.Common.props
           $TargetFramework = $CommonProps.Project.PropertyGroup |

--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -41,15 +41,10 @@ jobs:
             executable: pwsh
 
     steps:
-      - name: Clone project
-        uses: actions/checkout@v7.0.0
-
-      - name: Clone PowerShell source ${{env.POWERSHELL_SOURCE_REF}}
+      - name: Clone project with PowerShell submodule
         uses: actions/checkout@v7.0.0
         with:
-          repository: ${{env.POWERSHELL_SOURCE_REPOSITORY}}
-          ref: ${{env.POWERSHELL_SOURCE_REF}}
-          path: PowerShell
+          submodules: true
           fetch-depth: 0
 
       - name: Verify PowerShell source ref
@@ -441,15 +436,10 @@ jobs:
     needs: apphost
   
     steps:
-      - name: Clone project
-        uses: actions/checkout@v7.0.0
-
-      - name: Clone PowerShell source ${{env.POWERSHELL_SOURCE_REF}}
+      - name: Clone project with PowerShell submodule
         uses: actions/checkout@v7.0.0
         with:
-          repository: ${{env.POWERSHELL_SOURCE_REPOSITORY}}
-          ref: ${{env.POWERSHELL_SOURCE_REF}}
-          path: PowerShell
+          submodules: true
           fetch-depth: 0
 
       - name: Verify PowerShell source ref

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -40,15 +40,10 @@ jobs:
             runtime-os: linux
   
     steps:
-      - name: Clone project
-        uses: actions/checkout@v7.0.0
-
-      - name: Clone PowerShell source ${{env.POWERSHELL_SOURCE_REF}}
+      - name: Clone project with PowerShell submodule
         uses: actions/checkout@v7.0.0
         with:
-          repository: ${{env.POWERSHELL_SOURCE_REPOSITORY}}
-          ref: ${{env.POWERSHELL_SOURCE_REF}}
-          path: PowerShell
+          submodules: true
           fetch-depth: 0
 
       - name: Verify PowerShell source ref

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -2,7 +2,10 @@ name: PowerShell
 on: workflow_dispatch
 env:
   POWERSHELL_VERSION: "7.6.3"
-  POWERSHELL_REF: "v7.6.3"
+  POWERSHELL_RELEASE_TAG: "v7.6.3"
+  POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.3"
+  POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
+  POWERSHELL_SOURCE_REF: "release/v7.6.3"
 jobs:
   build:
     name: PowerShell [${{matrix.arch}}-${{matrix.os}}]
@@ -40,12 +43,65 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v7.0.0
 
-      - name: Clone PowerShell ${{env.POWERSHELL_VERSION}}
+      - name: Clone PowerShell source ${{env.POWERSHELL_SOURCE_REF}}
         uses: actions/checkout@v7.0.0
         with:
-          repository: PowerShell/PowerShell
-          ref: ${{env.POWERSHELL_REF}}
+          repository: ${{env.POWERSHELL_SOURCE_REPOSITORY}}
+          ref: ${{env.POWERSHELL_SOURCE_REF}}
           path: PowerShell
+          fetch-depth: 0
+
+      - name: Verify PowerShell source ref
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Invoke-GitPowerShell {
+            param(
+              [Parameter(Mandatory, ValueFromRemainingArguments)]
+              [string[]] $Arguments
+            )
+
+            $Output = & git -C PowerShell @Arguments
+            if ($LASTEXITCODE -ne 0) {
+              throw "git -C PowerShell $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+            }
+
+            return $Output
+          }
+
+          function Test-GitCommitRef {
+            param(
+              [Parameter(Mandatory)]
+              [string] $Ref
+            )
+
+            & git -C PowerShell rev-parse --verify "$Ref^{commit}" *> $null
+            return $LASTEXITCODE -eq 0
+          }
+
+          $ExpectedVersion = $Env:POWERSHELL_RELEASE_TAG -replace '^v', ''
+          if ($Env:POWERSHELL_VERSION -ne $ExpectedVersion) {
+            throw "POWERSHELL_VERSION '$Env:POWERSHELL_VERSION' does not match POWERSHELL_RELEASE_TAG '$Env:POWERSHELL_RELEASE_TAG'."
+          }
+
+          $SourceCommit = (Invoke-GitPowerShell rev-parse HEAD).Trim()
+          Write-Host "PowerShell source: $Env:POWERSHELL_SOURCE_REPOSITORY@$Env:POWERSHELL_SOURCE_REF ($SourceCommit)"
+
+          $BaseRef = if ($Env:POWERSHELL_SOURCE_REPOSITORY -eq $Env:GITHUB_REPOSITORY) {
+            $Env:POWERSHELL_UPSTREAM_TAG
+          } else {
+            $Env:POWERSHELL_RELEASE_TAG
+          }
+
+          if (-not (Test-GitCommitRef $BaseRef)) {
+            throw "Expected PowerShell base tag '$BaseRef' was not found in the PowerShell checkout."
+          }
+
+          & git -C PowerShell merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw "PowerShell source ref '$Env:POWERSHELL_SOURCE_REF' is not based on '$BaseRef'."
+          }
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0
@@ -88,7 +144,7 @@ jobs:
             ForMinimalSize = $false;
             Detailed = $true;
             Clean = $true;
-            ReleaseTag = $Env:POWERSHELL_REF;
+            ReleaseTag = $Env:POWERSHELL_RELEASE_TAG;
           }
           if ('${{matrix.os}}' -ne 'windows') {
             $PSBuildParams.UseNuGetOrg = $true

--- a/.github/workflows/sync-powershell-upstream.yml
+++ b/.github/workflows/sync-powershell-upstream.yml
@@ -1,0 +1,76 @@
+name: Sync PowerShell upstream
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  POWERSHELL_UPSTREAM_REPOSITORY: https://github.com/PowerShell/PowerShell.git
+  POWERSHELL_UPSTREAM_BRANCH: master
+
+jobs:
+  sync:
+    name: Sync upstream branch and tags
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Add PowerShell upstream remote
+        run: |
+          git remote add powershell "$POWERSHELL_UPSTREAM_REPOSITORY"
+
+      - name: Fetch PowerShell upstream branches
+        run: |
+          git fetch powershell --prune --no-tags
+
+      - name: Configure authenticated origin
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${SYNC_TOKEN}" ]; then
+            echo "::error::POWERSHELL_UPSTREAM_SYNC_TOKEN or DEVOLUTIONSBOT_WRITE_TOKEN is required to push upstream PowerShell refs because they can contain workflow files."
+            exit 1
+          fi
+
+          git remote set-url origin "https://x-access-token:${SYNC_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        env:
+          SYNC_TOKEN: ${{ secrets.POWERSHELL_UPSTREAM_SYNC_TOKEN || secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}
+
+      - name: Update upstream branch
+        run: |
+          git push origin "refs/remotes/powershell/${POWERSHELL_UPSTREAM_BRANCH}:refs/heads/upstream" --force
+
+      - name: Push upstream tags under namespace
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin --tags --force
+          git fetch powershell --prune --no-tags "+refs/tags/*:refs/tags/upstream/*"
+
+          tags_to_push=()
+          while IFS= read -r tag_ref; do
+            commit_sha=$(git rev-list -n 1 "$tag_ref")
+            if git diff-tree --no-commit-id --name-only -r "$commit_sha" -- ".github/workflows" | grep -q .; then
+              echo "Skipping tag ${tag_ref#refs/tags/} because the tagged commit changes workflow files."
+              continue
+            fi
+            tags_to_push+=("$tag_ref:$tag_ref")
+          done < <(git for-each-ref --format='%(refname)' refs/tags/upstream)
+
+          if [ ${#tags_to_push[@]} -eq 0 ]; then
+            echo "No upstream tags eligible for push."
+            exit 0
+          fi
+
+          printf '%s\n' "${tags_to_push[@]}" | xargs -n 50 git push origin

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 PowerShell/
+PowerShell-src/
 dotnet-runtime/
 output/
 package/
+patchsets/
 *.nupkg
 *.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-PowerShell/
 PowerShell-src/
 dotnet-runtime/
 output/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "PowerShell"]
+	path = PowerShell
+	url = ./
+	branch = release/v7.6.3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,14 @@ Keep version pins explicit in workflow `env` blocks. When updating PowerShell, u
 
 The repository uses a downstream patch branch model:
 
-- `master` is downstream-only and must not contain the upstream PowerShell source tree.
+- `master` is downstream-only and must not contain the upstream PowerShell source tree directly. The patched source is exposed as a same-repo git submodule at path `PowerShell/` (`url = ./`, `branch = release/vX.Y.Z`) pinned to a commit on the patch branch.
 - `upstream` mirrors `PowerShell/PowerShell` for traceability.
 - `upstream/vX.Y.Z` mirrors upstream PowerShell release tags.
 - `release/vX.Y.Z` branches contain full PowerShell sources plus downstream patches.
 - Downstream release tags use `vX.Y.Z.R`.
 
-In PowerShell workflows, keep the source checkout ref separate from build version metadata. `POWERSHELL_SOURCE_REF` can point at `release/vX.Y.Z`, but `POWERSHELL_RELEASE_TAG` should remain the upstream release tag passed to PowerShell build logic.
+In PowerShell workflows, keep the source checkout ref separate from build version metadata. `POWERSHELL_SOURCE_REF` can point at `release/vX.Y.Z`, but `POWERSHELL_RELEASE_TAG` should remain the upstream release tag passed to PowerShell build logic. Workflows check out the project with `actions/checkout` using `submodules: true` to populate `PowerShell/` from the pinned submodule commit; do not add a second `actions/checkout` for PowerShell source. When the patch branch is rebased and force-pushed, re-bump the `PowerShell` submodule pointer on `master` with `git submodule update --remote PowerShell` and commit that change.
 
 The `.NET runtime` workflow uses `awakecoding/llvm-prebuilt` assets. When refreshing it, verify the release tag and required `clang+llvm-<version>-x86_64-<platform>.tar.xz` assets exist before changing `CLANG_LLVM_VERSION`, `CLANG_LLVM_RELEASE`, or runner OS labels.
 
-Do not commit generated `PowerShell/`, `dotnet-runtime/`, package, archive, or build output directories. Prefer validating workflow edits with a YAML parser and `git diff --check` before finishing.
+`PowerShell/` is a tracked submodule, not a generated directory. Do not commit generated `dotnet-runtime/`, package, archive, or build output directories, and do not commit a locally generated `PowerShell-src/` worktree. Prefer validating workflow edits with a YAML parser and `git diff --check` before finishing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,17 @@
 
 This repository is a small GitHub Actions project for building PowerShell distribution artifacts. Treat `.github/workflows/powershell-sdk.yml` as the primary product surface and `.github/workflows/powershell.yml` as the secondary product surface.
 
-Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version/ref in both PowerShell workflows, verify the upstream target framework from `PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
+Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version, release tag, upstream tag, and source ref in both PowerShell workflows, verify the upstream target framework from `PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
+
+The repository uses a downstream patch branch model:
+
+- `master` is downstream-only and must not contain the upstream PowerShell source tree.
+- `upstream` mirrors `PowerShell/PowerShell` for traceability.
+- `upstream/vX.Y.Z` mirrors upstream PowerShell release tags.
+- `release/vX.Y.Z` branches contain full PowerShell sources plus downstream patches.
+- Downstream release tags use `vX.Y.Z.R`.
+
+In PowerShell workflows, keep the source checkout ref separate from build version metadata. `POWERSHELL_SOURCE_REF` can point at `release/vX.Y.Z`, but `POWERSHELL_RELEASE_TAG` should remain the upstream release tag passed to PowerShell build logic.
 
 The `.NET runtime` workflow uses `awakecoding/llvm-prebuilt` assets. When refreshing it, verify the release tag and required `clang+llvm-<version>-x86_64-<platform>.tar.xz` assets exist before changing `CLANG_LLVM_VERSION`, `CLANG_LLVM_RELEASE`, or runner OS labels.
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,80 @@
+# Branching and tagging strategy
+
+## Goals
+
+- Keep downstream automation and packaging separate from the upstream PowerShell source tree.
+- Carry Devolutions source patches on explicit per-release branches based on upstream PowerShell release tags.
+- Keep upstream and downstream refs distinct so workflow pins are auditable.
+
+## Branches
+
+- `master`
+  - Downstream distribution-only branch.
+  - Contains README, agent instructions, GitHub Actions workflows, helper scripts, and packaging logic.
+  - Do not add the upstream PowerShell source tree here.
+- `upstream`
+  - Mirror of the upstream `PowerShell/PowerShell` default branch.
+  - Used for traceability and local comparisons, not for downstream patches.
+- `release/vX.Y.Z`
+  - Downstream patch branch for one upstream PowerShell release.
+  - Created from the namespaced upstream tag `upstream/vX.Y.Z`.
+  - Contains the full PowerShell source tree plus downstream patch commits.
+
+## Tags
+
+- Upstream mirrored tags:
+  - `upstream/vX.Y.Z`
+  - Example: `upstream/v7.6.3`
+- Downstream release tags:
+  - `vX.Y.Z.R`
+  - `X.Y.Z` matches the upstream PowerShell version.
+  - `R` is the downstream revision for additional releases from the same upstream version.
+  - Example sequence for upstream `v7.6.3`: `v7.6.3.0`, `v7.6.3.1`, `v7.6.3.2`.
+
+Do not use plain `vX.Y.Z` downstream tags. Those names belong to upstream PowerShell and are mirrored only under `upstream/*`.
+
+## Release flow
+
+1. Sync the upstream mirror branch and upstream tags.
+2. Create a patch branch from the upstream release tag without switching the downstream `master` worktree:
+
+   ```powershell
+   .\scripts\New-PowerShellPatchBranch.ps1 -Version 7.6.3
+   ```
+
+3. Add a linked source worktree for `release/v7.6.3` and apply downstream PowerShell source patches there.
+4. Update workflow pins on `master` so `POWERSHELL_SOURCE_REF` points to the desired `release/vX.Y.Z` branch while `POWERSHELL_RELEASE_TAG` remains the upstream PowerShell release tag.
+5. Run the PowerShell SDK workflow first, then the PowerShell distribution workflow if the SDK package is valid.
+6. Tag downstream releases as `vX.Y.Z.R` when publishing artifacts externally.
+
+## Workflow pin model
+
+PowerShell workflows keep source checkout refs separate from release metadata:
+
+- `POWERSHELL_VERSION`: package and artifact version, for example `7.6.3`.
+- `POWERSHELL_RELEASE_TAG`: upstream release tag passed to PowerShell build metadata, for example `v7.6.3`.
+- `POWERSHELL_UPSTREAM_TAG`: mirrored upstream tag used for ancestry checks, for example `upstream/v7.6.3`.
+- `POWERSHELL_SOURCE_REPOSITORY`: repository containing the source branch, normally this repository.
+- `POWERSHELL_SOURCE_REF`: downstream source branch to build, for example `release/v7.6.3`.
+
+This prevents a downstream source branch such as `release/v7.6.3` from being passed to PowerShell build logic that expects an upstream release tag.
+
+## Local source worktree
+
+Keep local source checkouts out of `master` by using a linked worktree:
+
+```powershell
+git worktree add PowerShell-src release/v7.6.3
+```
+
+`PowerShell-src/` is ignored by this repository. Commit source patches in that worktree on the `release/vX.Y.Z` branch, not on `master`.
+
+## Patch export
+
+To export a squashed patch for review or archival:
+
+```powershell
+.\scripts\Export-PowerShellPatch.ps1 -RepoPath PowerShell-src -Branch release/v7.6.3
+```
+
+The script compares `upstream/v7.6.3...release/v7.6.3` and writes the patch under `patchsets/`, which is ignored by git.

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -5,6 +5,7 @@
 - Keep downstream automation and packaging separate from the upstream PowerShell source tree.
 - Carry Devolutions source patches on explicit per-release branches based on upstream PowerShell release tags.
 - Keep upstream and downstream refs distinct so workflow pins are auditable.
+- Expose the patched source on `master` as a pinned submodule so workflows build the exact reviewed tree without a second checkout.
 
 ## Branches
 
@@ -43,7 +44,7 @@ Do not use plain `vX.Y.Z` downstream tags. Those names belong to upstream PowerS
    ```
 
 3. Add a linked source worktree for `release/v7.6.3` and apply downstream PowerShell source patches there.
-4. Update workflow pins on `master` so `POWERSHELL_SOURCE_REF` points to the desired `release/vX.Y.Z` branch while `POWERSHELL_RELEASE_TAG` remains the upstream PowerShell release tag.
+4. Bump the `PowerShell` submodule on `master` to the updated `release/vX.Y.Z` tip and update workflow pins so `POWERSHELL_SOURCE_REF` points to the desired `release/vX.Y.Z` branch while `POWERSHELL_RELEASE_TAG` remains the upstream PowerShell release tag.
 5. Run the PowerShell SDK workflow first, then the PowerShell distribution workflow if the SDK package is valid.
 6. Tag downstream releases as `vX.Y.Z.R` when publishing artifacts externally.
 
@@ -59,15 +60,35 @@ PowerShell workflows keep source checkout refs separate from release metadata:
 
 This prevents a downstream source branch such as `release/v7.6.3` from being passed to PowerShell build logic that expects an upstream release tag.
 
+## Source submodule
+
+`master` exposes the patched PowerShell source tree as a same-repository git submodule at path `PowerShell/`:
+
+```ini
+[submodule "PowerShell"]
+    path = PowerShell
+    url = ./
+    branch = release/v7.6.3
+```
+
+The submodule pins a specific commit on `release/vX.Y.Z`, not the branch tip. Bumping the pointer is a normal commit on `master` and is reviewable in the PR diff. Workflows check out the project with `submodules: true`, which is enough to populate `PowerShell/` using the default `GITHUB_TOKEN`; no second `actions/checkout` and no extra secrets are needed.
+
+After rebasing `release/vX.Y.Z` (for example with an AI-assisted rebase that force-pushes the patch branch), re-bump the submodule on `master` so the pinned commit matches the new tip:
+
+```powershell
+git submodule update --remote PowerShell
+git add PowerShell
+```
+
 ## Local source worktree
 
-Keep local source checkouts out of `master` by using a linked worktree:
+The `PowerShell/` submodule on `master` is the build source of truth, but it is a detached checkout of the pinned commit. For developing patches, use a linked worktree on the patch branch:
 
 ```powershell
 git worktree add PowerShell-src release/v7.6.3
 ```
 
-`PowerShell-src/` is ignored by this repository. Commit source patches in that worktree on the `release/vX.Y.Z` branch, not on `master`.
+`PowerShell-src/` is ignored by this repository. Commit source patches in that worktree on the `release/vX.Y.Z` branch, not on `master`, then bump the submodule pointer on `master` as described above.
 
 ## Patch export
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ All workflows are manual and can be started from the GitHub Actions **Run workfl
 
 ## Branching model
 
-This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `release/vX.Y.Z` branches based on upstream release tags. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, and worktree flow.
+This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `release/vX.Y.Z` branches based on upstream release tags. The patched source is exposed on `master` as a same-repo submodule at `PowerShell/` pinned to a commit on `release/vX.Y.Z`, so workflows build the exact reviewed source tree with a single `actions/checkout` using `submodules: true`. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, submodule, and worktree flow.
 
 ## Notes
 
-The PowerShell workflows check out `POWERSHELL_SOURCE_REPOSITORY` at `POWERSHELL_SOURCE_REF` into `PowerShell/`, while build metadata continues to use `POWERSHELL_RELEASE_TAG`. This allows downstream patch branches such as `release/v7.6.3` to be built without passing branch names to PowerShell build steps that expect upstream release tags.
+The PowerShell workflows check out this repository with `submodules: true` to populate `PowerShell/` from the pinned submodule commit on `release/vX.Y.Z`, while build metadata continues to use `POWERSHELL_RELEASE_TAG`. This allows downstream patch branches to be built without passing branch names to PowerShell build steps that expect upstream release tags. `POWERSHELL_SOURCE_REF` documents which patch branch the submodule tracks; bumping the submodule pointer on `master` is what actually moves the built source.
 
 The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from locally built PowerShell binaries plus package layouts from the official NuGet packages for the same PowerShell version, then `eng/Vendor-PowerShellSdkPackage.ps1` rewrites the NuGet package ID and vendor metadata to Devolutions.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # pwsh-distro
 
-GitHub Actions workflows for building redistributable PowerShell artifacts from upstream source. The primary target is a single vendored `Devolutions.PowerShell.SDK` package, and the secondary target is a self-contained PowerShell distribution archive.
+GitHub Actions workflows for building redistributable PowerShell artifacts from upstream or downstream-patched source. The primary target is a single vendored `Devolutions.PowerShell.SDK` package, and the secondary target is a self-contained PowerShell distribution archive.
 
 ## Current pins
 
 | Component | Version |
 | --- | --- |
-| PowerShell | `7.6.3` / `v7.6.3` |
+| PowerShell upstream release | `7.6.3` / `v7.6.3` |
+| PowerShell downstream source ref | `release/v7.6.3` based on `upstream/v7.6.3` |
 | PowerShell target framework | `net10.0` |
 | PowerShell SDK package ID | `Devolutions.PowerShell.SDK` |
 | multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.0` |
@@ -26,7 +27,13 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 
 All workflows are manual and can be started from the GitHub Actions **Run workflow** button.
 
+## Branching model
+
+This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `release/vX.Y.Z` branches based on upstream release tags. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, and worktree flow.
+
 ## Notes
+
+The PowerShell workflows check out `POWERSHELL_SOURCE_REPOSITORY` at `POWERSHELL_SOURCE_REF` into `PowerShell/`, while build metadata continues to use `POWERSHELL_RELEASE_TAG`. This allows downstream patch branches such as `release/v7.6.3` to be built without passing branch names to PowerShell build steps that expect upstream release tags.
 
 The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from locally built PowerShell binaries plus package layouts from the official NuGet packages for the same PowerShell version, then `eng/Vendor-PowerShellSdkPackage.ps1` rewrites the NuGet package ID and vendor metadata to Devolutions.
 

--- a/scripts/Export-PowerShellPatch.ps1
+++ b/scripts/Export-PowerShellPatch.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+  [string] $RepoPath = 'PowerShell-src',
+
+  [string] $Branch,
+
+  [string] $BaseTag,
+
+  [string] $ReleaseVersion,
+
+  [string] $OutputDir = 'patchsets\squashed'
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $RepoPath -PathType Container)) {
+  throw "Repository path not found: $RepoPath"
+}
+
+function Invoke-GitSource {
+  param(
+    [Parameter(Mandatory, ValueFromRemainingArguments)]
+    [string[]] $Arguments
+  )
+
+  & git -C $RepoPath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git -C $RepoPath $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+if (-not $Branch) {
+  $Branch = (& git -C $RepoPath rev-parse --abbrev-ref HEAD).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Unable to determine current branch for $RepoPath"
+  }
+}
+
+if (-not $BaseTag) {
+  if ($Branch -match '^release/(v.+)$') {
+    $BaseTag = "upstream/$($Matches[1])"
+  } else {
+    throw "Could not infer base tag from branch '$Branch'. Pass -BaseTag explicitly."
+  }
+}
+
+if (-not $ReleaseVersion) {
+  if ($Branch -match '^release/v(.+)$') {
+    $ReleaseVersion = "$($Matches[1]).0"
+  } else {
+    throw "Could not infer release version from branch '$Branch'. Pass -ReleaseVersion explicitly."
+  }
+}
+
+Invoke-GitSource rev-parse --verify "$BaseTag^{commit}"
+
+$CommitCount = [int](& git -C $RepoPath rev-list --count "$BaseTag..$Branch").Trim()
+if ($LASTEXITCODE -ne 0) {
+  throw "Unable to count commits in range $BaseTag..$Branch"
+}
+if ($CommitCount -eq 0) {
+  throw "No commits found in range $BaseTag..$Branch"
+}
+
+New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+$OutputFile = Join-Path $OutputDir "powershell-patch-$ReleaseVersion.patch"
+
+$Diff = & git -C $RepoPath diff --binary "$BaseTag...$Branch"
+if ($LASTEXITCODE -ne 0) {
+  throw "Unable to generate diff for $BaseTag...$Branch"
+}
+if ([string]::IsNullOrWhiteSpace(($Diff -join [Environment]::NewLine))) {
+  throw "No diff produced for range $BaseTag...$Branch"
+}
+
+$Diff | Set-Content -Path $OutputFile -Encoding utf8
+
+Write-Output "Branch=$Branch"
+Write-Output "BaseTag=$BaseTag"
+Write-Output "ReleaseVersion=$ReleaseVersion"
+Write-Output "CommitCount=$CommitCount"
+Write-Output "OutputFile=$OutputFile"

--- a/scripts/New-PowerShellPatchBranch.ps1
+++ b/scripts/New-PowerShellPatchBranch.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [Parameter(Mandatory)]
+  [string] $Version,
+
+  [string] $BranchName,
+
+  [string] $UpstreamTag
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+  param(
+    [Parameter(Mandatory, ValueFromRemainingArguments)]
+    [string[]] $Arguments
+  )
+
+  & git @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Test-GitRef {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Ref
+  )
+
+  & git rev-parse --verify "$Ref^{commit}" *> $null
+  return $LASTEXITCODE -eq 0
+}
+
+$TagVersion = $Version.Trim()
+if (-not $TagVersion.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+  $TagVersion = "v$TagVersion"
+}
+
+if (-not $BranchName) {
+  $BranchName = "release/$TagVersion"
+}
+
+if (-not $UpstreamTag) {
+  $UpstreamTag = "upstream/$TagVersion"
+}
+
+if (-not (Test-GitRef $UpstreamTag)) {
+  throw "Upstream tag '$UpstreamTag' was not found. Run scripts\Sync-PowerShellUpstream.ps1 -SyncTags first."
+}
+
+& git show-ref --verify --quiet "refs/heads/$BranchName"
+if ($LASTEXITCODE -eq 0) {
+  throw "Branch '$BranchName' already exists."
+}
+
+if ($PSCmdlet.ShouldProcess($BranchName, "Create from $UpstreamTag")) {
+  Invoke-Git branch $BranchName $UpstreamTag
+}
+
+Write-Output "Branch=$BranchName"
+Write-Output "BaseTag=$UpstreamTag"
+Write-Output "WorktreeCommand=git worktree add PowerShell-src $BranchName"

--- a/scripts/Sync-PowerShellUpstream.ps1
+++ b/scripts/Sync-PowerShellUpstream.ps1
@@ -1,0 +1,87 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [string] $UpstreamRepository = 'https://github.com/PowerShell/PowerShell.git',
+
+  [string] $UpstreamBranch = 'master',
+
+  [string] $UpstreamRemote = 'powershell',
+
+  [string] $OriginRemote = 'origin',
+
+  [switch] $SyncTags,
+
+  [switch] $Push
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+  param(
+    [Parameter(Mandatory, ValueFromRemainingArguments)]
+    [string[]] $Arguments
+  )
+
+  & git @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Test-GitRemote {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Name
+  )
+
+  & git remote get-url $Name *> $null
+  return $LASTEXITCODE -eq 0
+}
+
+if (Test-GitRemote $UpstreamRemote) {
+  Invoke-Git remote set-url $UpstreamRemote $UpstreamRepository
+} else {
+  Invoke-Git remote add $UpstreamRemote $UpstreamRepository
+}
+
+Invoke-Git fetch $UpstreamRemote --prune --no-tags
+
+$RemoteBranchRef = "refs/remotes/$UpstreamRemote/$UpstreamBranch"
+Invoke-Git rev-parse --verify $RemoteBranchRef
+$UpstreamCommit = (& git rev-parse $RemoteBranchRef).Trim()
+if ($LASTEXITCODE -ne 0) {
+  throw "Unable to resolve $RemoteBranchRef"
+}
+
+if ($PSCmdlet.ShouldProcess('refs/heads/upstream', "Update to $UpstreamCommit")) {
+  Invoke-Git update-ref refs/heads/upstream $UpstreamCommit
+}
+
+if ($Push) {
+  if ($PSCmdlet.ShouldProcess($OriginRemote, 'Push refs/heads/upstream')) {
+    Invoke-Git push $OriginRemote refs/heads/upstream:refs/heads/upstream --force
+  }
+}
+
+if ($SyncTags) {
+  Invoke-Git fetch $UpstreamRemote --prune --no-tags '+refs/tags/*:refs/tags/upstream/*'
+  $Tags = @(git for-each-ref --format='%(refname)' refs/tags/upstream)
+  if ($LASTEXITCODE -ne 0) {
+    throw "Unable to enumerate refs/tags/upstream"
+  }
+
+  if ($Tags.Count -eq 0) {
+    Write-Host 'No upstream tags found.'
+    return
+  }
+
+  Write-Host "Synchronized $($Tags.Count) upstream tag(s) locally under refs/tags/upstream/*."
+
+  if ($Push) {
+    foreach ($Tag in $Tags) {
+      if ($PSCmdlet.ShouldProcess($OriginRemote, "Push $Tag")) {
+        Invoke-Git push $OriginRemote "$Tag`:$Tag"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adopts a structured downstream patch-branch model for PowerShell sources, inspired by `Devolutions/gsudo-distro`, and exposes the patched source on `master` as a same-repo git submodule so workflows build the exact reviewed tree.

## Branch / tag model

- `master` stays downstream-only (workflows, scripts, docs, packaging).
- `upstream` mirrors `PowerShell/PowerShell` for traceability.
- `upstream/vX.Y.Z` mirrors upstream PowerShell release tags (namespaced to avoid colliding with plain upstream tags).
- `release/vX.Y.Z` patch branches carry the full PowerShell source tree plus downstream patch commits, based off `upstream/vX.Y.Z`.
- Downstream release tags use `vX.Y.Z.R`.

Bootstrapped for `7.6.3`:
- Pushed `upstream/v7.6.3` tag -> commit `a1994c19a` (upstream `v7.6.3`).
- Created and pushed `release/v7.6.3` from that tag.

## Source submodule

`PowerShell/` is now a same-repo submodule on `master`:

```ini
[submodule "PowerShell"]
    path = PowerShell
    url = ./
    branch = release/v7.6.3
```

Pinned to `a1994c19a` (the `release/v7.6.3` tip = `upstream/v7.6.3`). This gives:
- Zero build-step churn - all workflow steps already reference `PowerShell/` (working-directory, `global-json-file`, `Import-Module` paths).
- A reviewable pointer bump on `master` whenever the patch branch moves.
- Single-checkout CI using the default `GITHUB_TOKEN`; no extra secrets.

## Workflow changes

Both `powershell-sdk.yml` and `powershell.yml`:
- Split source refs from release metadata in `env`: `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG` (upstream tag passed to build logic), `POWERSHELL_UPSTREAM_TAG` (namespaced mirror for ancestry checks), `POWERSHELL_SOURCE_REPOSITORY`, `POWERSHELL_SOURCE_REF`.
- Replaced the second `actions/checkout` (Clone PowerShell source) with a single `actions/checkout@v7.0.0` using `submodules: true` and `fetch-depth: 0`.
- Added a source-ancestry preflight that verifies `POWERSHELL_VERSION` matches `POWERSHELL_RELEASE_TAG`, confirms the expected base tag exists in the checkout, and asserts `release/vX.Y.Z` is a descendant of the upstream tag.

## New files

- `BRANCHING.md` - documents the branch/tag model, release flow, workflow pin model, source submodule, local worktree usage, and patch export.
- `.github/workflows/sync-powershell-upstream.yml` - manual workflow to mirror the upstream branch and namespaced tags with PAT-before-push auth and `--no-tags` to avoid plain tag pollution.
- `scripts/Sync-PowerShellUpstream.ps1` - local helper to sync the upstream mirror branch and optionally tags.
- `scripts/New-PowerShellPatchBranch.ps1` - creates `release/vX.Y.Z` from `upstream/vX.Y.Z` using `git branch` (does not switch the `master` worktree).
- `scripts/Export-PowerShellPatch.ps1` - exports a squashed patch from `upstream/vX.Y.Z...release/vX.Y.Z` into the gitignored `patchsets/` directory.

## Other changes

- `.gitignore`: added `PowerShell-src/` (local worktree) and `patchsets/`; removed the stale `PowerShell/` ignore (now a tracked submodule).
- `README.md`: updated pins table and branching-model section.
- `AGENTS.md`: added branch-model rules, submodule guidance, and the re-bump procedure after rebasing the patch branch.

## Post-rebase follow-up

After an AI-assisted rebase force-pushes `release/v7.6.3`, the only follow-up on `master` is:

```powershell
git submodule update --remote PowerShell
git add PowerShell
```

...which is a one-line, reviewable pointer bump.

## Validation

- All workflow YAML parsed with `js-yaml`.
- `git diff --check` clean.
- Upstream `v7.6.3` tag resolves to `a1994c19a`; `PowerShell.Common.props` confirms `<TargetFramework>net10.0</TargetFramework>`.
- Submodule status: `a1994c19a0badf524d714cacffe7986c5c8613c6 PowerShell (v7.6.3-0-ga1994c19a)`.