### PR TITLE
Rename downstream patch branches to downstream/ and submodule path to pwsh-src

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -5,7 +5,7 @@ env:
   POWERSHELL_RELEASE_TAG: "v7.6.3"
   POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.3"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "release/v7.6.3"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.3"
   SDK_VENDOR_NAME: "Devolutions"
   SDK_PACKAGE_ID: "Devolutions.PowerShell.SDK"
   MULTI_PWSH_APPHOST_PACKAGE_ID: "Devolutions.MultiPwsh.Cli"
@@ -58,9 +58,9 @@ jobs:
               [string[]] $Arguments
             )
 
-            $Output = & git -C PowerShell @Arguments
+            $Output = & git -C pwsh-src @Arguments
             if ($LASTEXITCODE -ne 0) {
-              throw "git -C PowerShell $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+              throw "git -C pwsh-src $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
             }
 
             return $Output
@@ -72,7 +72,7 @@ jobs:
               [string] $Ref
             )
 
-            & git -C PowerShell rev-parse --verify "$Ref^{commit}" *> $null
+            & git -C pwsh-src rev-parse --verify "$Ref^{commit}" *> $null
             return $LASTEXITCODE -eq 0
           }
 
@@ -94,7 +94,7 @@ jobs:
             throw "Expected PowerShell base tag '$BaseRef' was not found in the PowerShell checkout."
           }
 
-          & git -C PowerShell merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
+          & git -C pwsh-src merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
           if ($LASTEXITCODE -ne 0) {
             throw "PowerShell source ref '$Env:POWERSHELL_SOURCE_REF' is not based on '$BaseRef'."
           }
@@ -102,11 +102,11 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0
         with:
-          global-json-file: PowerShell/global.json
+          global-json-file: pwsh-src/global.json
 
       - name: Build PowerShell apphost
         shell: pwsh
-        working-directory: PowerShell
+        working-directory: pwsh-src
         run: |
           $ErrorActionPreference = 'Stop'
           Import-Module .\build.psm1 -Force
@@ -409,7 +409,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $StagePath = "PowerShell/apphost-package/${{matrix.rid}}"
+          $StagePath = "pwsh-src/apphost-package/${{matrix.rid}}"
           foreach ($FileName in @("${{matrix.executable}}", "pwsh.dll", "pwsh.runtimeconfig.json")) {
             $FilePath = Join-Path $StagePath $FileName
             if (-not (Test-Path $FilePath -PathType Leaf)) {
@@ -421,14 +421,14 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: PowerShell-SDK-AppHost-${{matrix.rid}}
-          path: PowerShell/apphost-package/${{matrix.rid}}/*
+          path: pwsh-src/apphost-package/${{matrix.rid}}/*
 
       - name: Upload package runtime libraries
         if: ${{ matrix.rid == 'win-x64' || matrix.rid == 'linux-x64' }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: PowerShell-SDK-PackageRuntime-${{matrix.rid}}
-          path: PowerShell/package-runtime/${{matrix.rid}}/*
+          path: pwsh-src/package-runtime/${{matrix.rid}}/*
 
   build:
     name: PowerShell SDK [7.6.3]
@@ -453,9 +453,9 @@ jobs:
               [string[]] $Arguments
             )
 
-            $Output = & git -C PowerShell @Arguments
+            $Output = & git -C pwsh-src @Arguments
             if ($LASTEXITCODE -ne 0) {
-              throw "git -C PowerShell $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+              throw "git -C pwsh-src $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
             }
 
             return $Output
@@ -467,7 +467,7 @@ jobs:
               [string] $Ref
             )
 
-            & git -C PowerShell rev-parse --verify "$Ref^{commit}" *> $null
+            & git -C pwsh-src rev-parse --verify "$Ref^{commit}" *> $null
             return $LASTEXITCODE -eq 0
           }
 
@@ -489,7 +489,7 @@ jobs:
             throw "Expected PowerShell base tag '$BaseRef' was not found in the PowerShell checkout."
           }
 
-          & git -C PowerShell merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
+          & git -C pwsh-src merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
           if ($LASTEXITCODE -ne 0) {
             throw "PowerShell source ref '$Env:POWERSHELL_SOURCE_REF' is not based on '$BaseRef'."
           }
@@ -497,7 +497,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0
         with:
-          global-json-file: PowerShell/global.json
+          global-json-file: pwsh-src/global.json
 
       - name: Download PowerShell apphosts
         uses: actions/download-artifact@v8.0.1
@@ -523,7 +523,7 @@ jobs:
 
       - name: Build PowerShell SDK
         shell: pwsh
-        working-directory: PowerShell
+        working-directory: pwsh-src
         run: |
           $ErrorActionPreference = 'Stop'
           Import-Module .\build.psm1 -Force
@@ -747,7 +747,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           ./eng/Validate-PowerShellSdkPackage.ps1 `
-            -PackageDirectory ./PowerShell/package `
+            -PackageDirectory ./pwsh-src/package `
             -PowerShellVersion $Env:POWERSHELL_VERSION `
             -TargetFramework $Env:POWERSHELL_TARGET_FRAMEWORK `
             -RuntimeIdentifier linux-x64 `
@@ -758,4 +758,5 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         with:
           name: PowerShell-SDK-${{env.POWERSHELL_VERSION}}
-          path: "PowerShell/package/*.nupkg"
+          path: "pwsh-src/package/*.nupkg"
+

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -5,7 +5,7 @@ env:
   POWERSHELL_RELEASE_TAG: "v7.6.3"
   POWERSHELL_UPSTREAM_TAG: "upstream/v7.6.3"
   POWERSHELL_SOURCE_REPOSITORY: ${{ github.repository }}
-  POWERSHELL_SOURCE_REF: "release/v7.6.3"
+  POWERSHELL_SOURCE_REF: "downstream/v7.6.3"
 jobs:
   build:
     name: PowerShell [${{matrix.arch}}-${{matrix.os}}]
@@ -57,9 +57,9 @@ jobs:
               [string[]] $Arguments
             )
 
-            $Output = & git -C PowerShell @Arguments
+            $Output = & git -C pwsh-src @Arguments
             if ($LASTEXITCODE -ne 0) {
-              throw "git -C PowerShell $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+              throw "git -C pwsh-src $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
             }
 
             return $Output
@@ -71,7 +71,7 @@ jobs:
               [string] $Ref
             )
 
-            & git -C PowerShell rev-parse --verify "$Ref^{commit}" *> $null
+            & git -C pwsh-src rev-parse --verify "$Ref^{commit}" *> $null
             return $LASTEXITCODE -eq 0
           }
 
@@ -93,7 +93,7 @@ jobs:
             throw "Expected PowerShell base tag '$BaseRef' was not found in the PowerShell checkout."
           }
 
-          & git -C PowerShell merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
+          & git -C pwsh-src merge-base --is-ancestor "${BaseRef}^{commit}" HEAD
           if ($LASTEXITCODE -ne 0) {
             throw "PowerShell source ref '$Env:POWERSHELL_SOURCE_REF' is not based on '$BaseRef'."
           }
@@ -101,18 +101,18 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0
         with:
-          global-json-file: PowerShell/global.json
+          global-json-file: pwsh-src/global.json
 
       - name: Bootstrap PowerShell
         shell: pwsh
         run: |
-          Import-Module "./PowerShell/build.psm1" -Force
+          Import-Module "./pwsh-src/build.psm1" -Force
           Start-PSBootstrap -Scenario DotNet
 
       - name: Build PowerShell
         shell: pwsh
         run: |
-          Import-Module "./PowerShell/build.psm1" -Force
+          Import-Module "./pwsh-src/build.psm1" -Force
           if ('${{matrix.os}}' -eq 'windows') {
             Switch-PSNugetConfig -Source Public
             $ModuleNugetConfig = @(
@@ -127,7 +127,7 @@ jobs:
               '  </disabledPackageSources>',
               '</configuration>'
             )
-            Set-Content -Path "./PowerShell/src/Modules/nuget.config" -Value $ModuleNugetConfig -Encoding utf8
+            Set-Content -Path "./pwsh-src/src/Modules/nuget.config" -Value $ModuleNugetConfig -Encoding utf8
           }
           $Runtime = "${{matrix.runtime-os}}-${{matrix.arch}}"
           $OutputPath = Join-Path $PWD "PowerShell-$Env:POWERSHELL_VERSION-${{matrix.os}}-${{matrix.arch}}"
@@ -152,3 +152,4 @@ jobs:
         with:
           name: PowerShell-${{env.POWERSHELL_VERSION}}-${{matrix.os}}-${{matrix.arch}}
           path: PowerShell-${{env.POWERSHELL_VERSION}}-${{matrix.os}}-${{matrix.arch}}.tar.gz
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-PowerShell-src/
+pwsh-src-worktree/
 dotnet-runtime/
 output/
 package/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "PowerShell"]
-	path = PowerShell
+[submodule "pwsh-src"]
+	path = pwsh-src
 	url = ./
-	branch = release/v7.6.3
+	branch = downstream/v7.6.3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,18 @@
 
 This repository is a small GitHub Actions project for building PowerShell distribution artifacts. Treat `.github/workflows/powershell-sdk.yml` as the primary product surface and `.github/workflows/powershell.yml` as the secondary product surface.
 
-Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version, release tag, upstream tag, and source ref in both PowerShell workflows, verify the upstream target framework from `PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
+Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version, release tag, upstream tag, and source ref in both PowerShell workflows, verify the upstream target framework from `pwsh-src/PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
 
 The repository uses a downstream patch branch model:
 
-- `master` is downstream-only and must not contain the upstream PowerShell source tree directly. The patched source is exposed as a same-repo git submodule at path `PowerShell/` (`url = ./`, `branch = release/vX.Y.Z`) pinned to a commit on the patch branch.
+- `master` is downstream-only and must not contain the upstream PowerShell source tree directly. The patched source is exposed as a same-repo git submodule at path `pwsh-src/` (`url = ./`, `branch = downstream/vX.Y.Z`) pinned to a commit on the patch branch.
 - `upstream` mirrors `PowerShell/PowerShell` for traceability.
 - `upstream/vX.Y.Z` mirrors upstream PowerShell release tags.
-- `release/vX.Y.Z` branches contain full PowerShell sources plus downstream patches.
+- `downstream/vX.Y.Z` branches contain full PowerShell sources plus downstream patches.
 - Downstream release tags use `vX.Y.Z.R`.
 
-In PowerShell workflows, keep the source checkout ref separate from build version metadata. `POWERSHELL_SOURCE_REF` can point at `release/vX.Y.Z`, but `POWERSHELL_RELEASE_TAG` should remain the upstream release tag passed to PowerShell build logic. Workflows check out the project with `actions/checkout` using `submodules: true` to populate `PowerShell/` from the pinned submodule commit; do not add a second `actions/checkout` for PowerShell source. When the patch branch is rebased and force-pushed, re-bump the `PowerShell` submodule pointer on `master` with `git submodule update --remote PowerShell` and commit that change.
+In PowerShell workflows, keep the source checkout ref separate from build version metadata. `POWERSHELL_SOURCE_REF` can point at `downstream/vX.Y.Z`, but `POWERSHELL_RELEASE_TAG` should remain the upstream release tag passed to PowerShell build logic. Workflows check out the project with `actions/checkout` using `submodules: true` to populate `pwsh-src/` from the pinned submodule commit; do not add a second `actions/checkout` for PowerShell source. When the patch branch is rebased and force-pushed, re-bump the `pwsh-src` submodule pointer on `master` with `git submodule update --remote pwsh-src` and commit that change.
 
 The `.NET runtime` workflow uses `awakecoding/llvm-prebuilt` assets. When refreshing it, verify the release tag and required `clang+llvm-<version>-x86_64-<platform>.tar.xz` assets exist before changing `CLANG_LLVM_VERSION`, `CLANG_LLVM_RELEASE`, or runner OS labels.
 
-`PowerShell/` is a tracked submodule, not a generated directory. Do not commit generated `dotnet-runtime/`, package, archive, or build output directories, and do not commit a locally generated `PowerShell-src/` worktree. Prefer validating workflow edits with a YAML parser and `git diff --check` before finishing.
+`pwsh-src/` is a tracked submodule, not a generated directory. Do not commit generated `dotnet-runtime/`, package, archive, or build output directories, and do not commit a locally generated `pwsh-src-worktree/` worktree. Prefer validating workflow edits with a YAML parser and `git diff --check` before finishing.

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -16,7 +16,7 @@
 - `upstream`
   - Mirror of the upstream `PowerShell/PowerShell` default branch.
   - Used for traceability and local comparisons, not for downstream patches.
-- `release/vX.Y.Z`
+- `downstream/vX.Y.Z`
   - Downstream patch branch for one upstream PowerShell release.
   - Created from the namespaced upstream tag `upstream/vX.Y.Z`.
   - Contains the full PowerShell source tree plus downstream patch commits.
@@ -43,8 +43,8 @@ Do not use plain `vX.Y.Z` downstream tags. Those names belong to upstream PowerS
    .\scripts\New-PowerShellPatchBranch.ps1 -Version 7.6.3
    ```
 
-3. Add a linked source worktree for `release/v7.6.3` and apply downstream PowerShell source patches there.
-4. Bump the `PowerShell` submodule on `master` to the updated `release/vX.Y.Z` tip and update workflow pins so `POWERSHELL_SOURCE_REF` points to the desired `release/vX.Y.Z` branch while `POWERSHELL_RELEASE_TAG` remains the upstream PowerShell release tag.
+3. Add a linked source worktree for `downstream/v7.6.3` and apply downstream PowerShell source patches there.
+4. Bump the `pwsh-src` submodule on `master` to the updated `downstream/vX.Y.Z` tip and update workflow pins so `POWERSHELL_SOURCE_REF` points to the desired `downstream/vX.Y.Z` branch while `POWERSHELL_RELEASE_TAG` remains the upstream PowerShell release tag.
 5. Run the PowerShell SDK workflow first, then the PowerShell distribution workflow if the SDK package is valid.
 6. Tag downstream releases as `vX.Y.Z.R` when publishing artifacts externally.
 
@@ -56,46 +56,46 @@ PowerShell workflows keep source checkout refs separate from release metadata:
 - `POWERSHELL_RELEASE_TAG`: upstream release tag passed to PowerShell build metadata, for example `v7.6.3`.
 - `POWERSHELL_UPSTREAM_TAG`: mirrored upstream tag used for ancestry checks, for example `upstream/v7.6.3`.
 - `POWERSHELL_SOURCE_REPOSITORY`: repository containing the source branch, normally this repository.
-- `POWERSHELL_SOURCE_REF`: downstream source branch to build, for example `release/v7.6.3`.
+- `POWERSHELL_SOURCE_REF`: downstream source branch to build, for example `downstream/v7.6.3`.
 
-This prevents a downstream source branch such as `release/v7.6.3` from being passed to PowerShell build logic that expects an upstream release tag.
+This prevents a downstream source branch such as `downstream/v7.6.3` from being passed to PowerShell build logic that expects an upstream release tag.
 
 ## Source submodule
 
-`master` exposes the patched PowerShell source tree as a same-repository git submodule at path `PowerShell/`:
+`master` exposes the patched PowerShell source tree as a same-repository git submodule at path `pwsh-src/`:
 
 ```ini
-[submodule "PowerShell"]
-    path = PowerShell
+[submodule "pwsh-src"]
+    path = pwsh-src
     url = ./
-    branch = release/v7.6.3
+    branch = downstream/v7.6.3
 ```
 
-The submodule pins a specific commit on `release/vX.Y.Z`, not the branch tip. Bumping the pointer is a normal commit on `master` and is reviewable in the PR diff. Workflows check out the project with `submodules: true`, which is enough to populate `PowerShell/` using the default `GITHUB_TOKEN`; no second `actions/checkout` and no extra secrets are needed.
+The submodule pins a specific commit on `downstream/vX.Y.Z`, not the branch tip. Bumping the pointer is a normal commit on `master` and is reviewable in the PR diff. Workflows check out the project with `submodules: true`, which is enough to populate `pwsh-src/` using the default `GITHUB_TOKEN`; no second `actions/checkout` and no extra secrets are needed.
 
-After rebasing `release/vX.Y.Z` (for example with an AI-assisted rebase that force-pushes the patch branch), re-bump the submodule on `master` so the pinned commit matches the new tip:
+After rebasing `downstream/vX.Y.Z` (for example with an AI-assisted rebase that force-pushes the patch branch), re-bump the submodule on `master` so the pinned commit matches the new tip:
 
 ```powershell
-git submodule update --remote PowerShell
-git add PowerShell
+git submodule update --remote pwsh-src
+git add pwsh-src
 ```
 
 ## Local source worktree
 
-The `PowerShell/` submodule on `master` is the build source of truth, but it is a detached checkout of the pinned commit. For developing patches, use a linked worktree on the patch branch:
+The `pwsh-src/` submodule on `master` is the build source of truth, but it is a detached checkout of the pinned commit. For developing patches, use a linked worktree on the patch branch:
 
 ```powershell
-git worktree add PowerShell-src release/v7.6.3
+git worktree add pwsh-src-worktree downstream/v7.6.3
 ```
 
-`PowerShell-src/` is ignored by this repository. Commit source patches in that worktree on the `release/vX.Y.Z` branch, not on `master`, then bump the submodule pointer on `master` as described above.
+`pwsh-src-worktree/` is ignored by this repository. Commit source patches in that worktree on the `downstream/vX.Y.Z` branch, not on `master`, then bump the submodule pointer on `master` as described above.
 
 ## Patch export
 
 To export a squashed patch for review or archival:
 
 ```powershell
-.\scripts\Export-PowerShellPatch.ps1 -RepoPath PowerShell-src -Branch release/v7.6.3
+.\scripts\Export-PowerShellPatch.ps1 -RepoPath pwsh-src-worktree -Branch downstream/v7.6.3
 ```
 
-The script compares `upstream/v7.6.3...release/v7.6.3` and writes the patch under `patchsets/`, which is ignored by git.
+The script compares `upstream/v7.6.3...downstream/v7.6.3` and writes the patch under `patchsets/`, which is ignored by git.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 | Component | Version |
 | --- | --- |
 | PowerShell upstream release | `7.6.3` / `v7.6.3` |
-| PowerShell downstream source ref | `release/v7.6.3` based on `upstream/v7.6.3` |
+| PowerShell downstream source ref | `downstream/v7.6.3` based on `upstream/v7.6.3` |
 | PowerShell target framework | `net10.0` |
 | PowerShell SDK package ID | `Devolutions.PowerShell.SDK` |
 | multi-pwsh apphost package | `Devolutions.MultiPwsh.Cli` / `0.14.0` |
@@ -29,11 +29,11 @@ All workflows are manual and can be started from the GitHub Actions **Run workfl
 
 ## Branching model
 
-This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `release/vX.Y.Z` branches based on upstream release tags. The patched source is exposed on `master` as a same-repo submodule at `PowerShell/` pinned to a commit on `release/vX.Y.Z`, so workflows build the exact reviewed source tree with a single `actions/checkout` using `submodules: true`. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, submodule, and worktree flow.
+This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `downstream/vX.Y.Z` branches based on upstream release tags. The patched source is exposed on `master` as a same-repo submodule at `pwsh-src/` pinned to a commit on `downstream/vX.Y.Z`, so workflows build the exact reviewed source tree with a single `actions/checkout` using `submodules: true`. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, submodule, and worktree flow.
 
 ## Notes
 
-The PowerShell workflows check out this repository with `submodules: true` to populate `PowerShell/` from the pinned submodule commit on `release/vX.Y.Z`, while build metadata continues to use `POWERSHELL_RELEASE_TAG`. This allows downstream patch branches to be built without passing branch names to PowerShell build steps that expect upstream release tags. `POWERSHELL_SOURCE_REF` documents which patch branch the submodule tracks; bumping the submodule pointer on `master` is what actually moves the built source.
+The PowerShell workflows check out this repository with `submodules: true` to populate `pwsh-src/` from the pinned submodule commit on `downstream/vX.Y.Z`, while build metadata continues to use `POWERSHELL_RELEASE_TAG`. This allows downstream patch branches to be built without passing branch names to PowerShell build steps that expect upstream release tags. `POWERSHELL_SOURCE_REF` documents which patch branch the submodule tracks; bumping the submodule pointer on `master` is what actually moves the built source.
 
 The SDK workflow intentionally derives the target framework from upstream `PowerShell.Common.props` instead of hardcoding it, so future PowerShell updates only need the version pins refreshed. The SDK package is assembled from locally built PowerShell binaries plus package layouts from the official NuGet packages for the same PowerShell version, then `eng/Vendor-PowerShellSdkPackage.ps1` rewrites the NuGet package ID and vendor metadata to Devolutions.
 

--- a/scripts/Export-PowerShellPatch.ps1
+++ b/scripts/Export-PowerShellPatch.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-  [string] $RepoPath = 'PowerShell-src',
+  [string] $RepoPath = 'pwsh-src-worktree',
 
   [string] $Branch,
 
@@ -38,7 +38,7 @@ if (-not $Branch) {
 }
 
 if (-not $BaseTag) {
-  if ($Branch -match '^release/(v.+)$') {
+  if ($Branch -match '^downstream/(v.+)$') {
     $BaseTag = "upstream/$($Matches[1])"
   } else {
     throw "Could not infer base tag from branch '$Branch'. Pass -BaseTag explicitly."
@@ -46,7 +46,7 @@ if (-not $BaseTag) {
 }
 
 if (-not $ReleaseVersion) {
-  if ($Branch -match '^release/v(.+)$') {
+  if ($Branch -match '^downstream/v(.+)$') {
     $ReleaseVersion = "$($Matches[1]).0"
   } else {
     throw "Could not infer release version from branch '$Branch'. Pass -ReleaseVersion explicitly."

--- a/scripts/New-PowerShellPatchBranch.ps1
+++ b/scripts/New-PowerShellPatchBranch.ps1
@@ -39,7 +39,7 @@ if (-not $TagVersion.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCas
 }
 
 if (-not $BranchName) {
-  $BranchName = "release/$TagVersion"
+  $BranchName = "downstream/$TagVersion"
 }
 
 if (-not $UpstreamTag) {
@@ -61,4 +61,4 @@ if ($PSCmdlet.ShouldProcess($BranchName, "Create from $UpstreamTag")) {
 
 Write-Output "Branch=$BranchName"
 Write-Output "BaseTag=$UpstreamTag"
-Write-Output "WorktreeCommand=git worktree add PowerShell-src $BranchName"
+Write-Output "WorktreeCommand=git worktree add pwsh-src-worktree $BranchName"

--- a/scripts/Sync-PowerShellUpstream.ps1
+++ b/scripts/Sync-PowerShellUpstream.ps1
@@ -10,7 +10,9 @@ param(
 
   [switch] $SyncTags,
 
-  [switch] $Push
+  [switch] $Push,
+
+  [string] $TagIncludePattern = 'v[8-9].*|v7\.[6-9](\.|-|$|preview|rc)'
 )
 
 Set-StrictMode -Version 3.0
@@ -64,6 +66,10 @@ if ($Push) {
 }
 
 if ($SyncTags) {
+  # Fetch all upstream tags into refs/tags/upstream/*, then prune to those
+  # matching TagIncludePattern. Filtering after fetch keeps the refspec stable
+  # (git refspecs do not support arbitrary regexes) while avoiding deleting
+  # unrelated tags that may exist under refs/tags/upstream/* on the remote.
   Invoke-Git fetch $UpstreamRemote --prune --no-tags '+refs/tags/*:refs/tags/upstream/*'
   $Tags = @(git for-each-ref --format='%(refname)' refs/tags/upstream)
   if ($LASTEXITCODE -ne 0) {
@@ -75,10 +81,25 @@ if ($SyncTags) {
     return
   }
 
-  Write-Host "Synchronized $($Tags.Count) upstream tag(s) locally under refs/tags/upstream/*."
+  $Kept = @()
+  $Dropped = @()
+  foreach ($Tag in $Tags) {
+    $ShortName = $Tag -replace '^refs/tags/upstream/',''
+    if ($ShortName -match $TagIncludePattern) {
+      $Kept += $Tag
+    } else {
+      $Dropped += $Tag
+    }
+  }
+
+  if ($Dropped.Count -gt 0) {
+    Invoke-Git tag -d @($Dropped | ForEach-Object { $_ -replace '^refs/tags/','' })
+  }
+
+  Write-Host "Kept $($Kept.Count) upstream tag(s) matching '$TagIncludePattern'; dropped $($Dropped.Count) non-matching tag(s)."
 
   if ($Push) {
-    foreach ($Tag in $Tags) {
+    foreach ($Tag in $Kept) {
       if ($PSCmdlet.ShouldProcess($OriginRemote, "Push $Tag")) {
         Invoke-Git push $OriginRemote "$Tag`:$Tag"
       }

--- a/scripts/Sync-PowerShellUpstream.ps1
+++ b/scripts/Sync-PowerShellUpstream.ps1
@@ -12,7 +12,7 @@ param(
 
   [switch] $Push,
 
-  [string] $TagIncludePattern = 'v[8-9].*|v7\.[6-9](\.|-|$|preview|rc)'
+  [string] $TagIncludePattern = '^v(?:[8-9]\.\d+\.\d+|7\.[6-9]\.\d+)$'
 )
 
 Set-StrictMode -Version 3.0


### PR DESCRIPTION
## Summary

Renames the downstream patch branch namespace `release/vX.Y.Z` → `downstream/vX.Y.Z` and the `master` submodule path `PowerShell/` → `pwsh-src/`. Follow-up to #6.

## Motivation

- **`release/*` collides with upstream PowerShell's own `release/*` branches.** The `upstream/*` tag namespace already avoids this for tags; `downstream/vX.Y.Z` mirrors that for branches and reads as the clear counterpart to `upstream/*`.
- **`pwsh-src/`** is a clearer workspace-root path for the PowerShell source submodule than the overloaded `PowerShell/`.

## Changes

**Branches (already done on origin):**
- Renamed `release/v7.6.3` → `downstream/v7.6.3` (local + origin). Submodule pin commit unchanged (`a1994c19a`).

**Files (11):**
- `.gitmodules` — submodule `pwsh-src`, `branch = downstream/v7.6.3`
- `.github/workflows/powershell-sdk.yml`, `powershell.yml` — `POWERSHELL_SOURCE_REF: "downstream/v7.6.3"`, `git -C pwsh-src`, `global-json-file: pwsh-src/global.json`, `working-directory: pwsh-src`, package/apphost paths under `pwsh-src/`
- `scripts/New-PowerShellPatchBranch.ps1` — default branch `downstream/<ver>`, worktree command `git worktree add pwsh-src-worktree <branch>`
- `scripts/Export-PowerShellPatch.ps1` — infers base tag/version from `^downstream/(v.+)$`, default `RepoPath = pwsh-src-worktree`
- `scripts/Sync-PowerShellUpstream.ps1` — new `-TagIncludePattern` param (default `^v(?:[8-9]\.\d+\.\d+|7\.[6-9]\.\d+)$`, stable-only) prunes non-matching upstream tags after fetch so only stable `v7.6+` releases are mirrored going forward
- `BRANCHING.md`, `README.md`, `AGENTS.md` — updated all references
- `.gitignore` — `PowerShell-src/` → `pwsh-src-worktree/`

## Notes

- The `PowerShell/` → `pwsh-src/` submodule move is a clean `R100` rename in the index; the pinned commit is unchanged, so no rebuild is implied.
- Upstream tag mirror pruned to stable-only: 4 tags remain (`upstream/v7.6.0`..`v7.6.3`); 219 older/non-stable tags (v7.5.* and below, SD/*, and v7.6.0 previews/rc + v7.7.0 previews) were deleted from local and origin. The new `-TagIncludePattern` keeps future syncs scoped to stable `v7.6+`.
- The GitHub Actions `sync-powershell-upstream.yml` workflow keeps its broader tag-mirroring logic (with the workflow-file safety check); only the local PowerShell script gained the version filter. A follow-up could port the filter to the workflow if desired.

## Validation

- All workflow YAML files parse (validated via `yaml` parser).
- `git submodule status pwsh-src` → initialized at `a1994c19a` (`v7.6.3-0-ga1994c19a`).
- `downstream/v7.6.3` confirmed based on `upstream/v7.6.3` (merge-base ancestor check passed).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
