### PR TITLE
Make repo clone-and-build friendly

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -41,6 +41,10 @@ jobs:
             executable: pwsh
 
     steps:
+      - name: Enable Windows long path support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Clone project with PowerShell submodule
         uses: actions/checkout@v7.0.0
         with:
@@ -436,6 +440,10 @@ jobs:
     needs: apphost
   
     steps:
+      - name: Enable Windows long path support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Clone project with PowerShell submodule
         uses: actions/checkout@v7.0.0
         with:

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -40,6 +40,10 @@ jobs:
             runtime-os: linux
   
     steps:
+      - name: Enable Windows long path support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Clone project with PowerShell submodule
         uses: actions/checkout@v7.0.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repository is a small GitHub Actions project for building PowerShell distribution artifacts. Treat `.github/workflows/powershell-sdk.yml` as the primary product surface and `.github/workflows/powershell.yml` as the secondary product surface.
 
-Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version, release tag, upstream tag, and source ref in both PowerShell workflows, verify the upstream target framework from `pwsh-src/PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
+Keep version pins explicit in workflow `env` blocks. When updating PowerShell, update the PowerShell version, release tag, upstream tag, and source ref in both PowerShell workflows, verify the upstream target framework from `pwsh-src/PowerShell.Common.props`, and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders. The version bump is four coordinated edits in one PR: the `POWERSHELL_*` env vars in both PowerShell workflows, the `branch = downstream/vX.Y.Z` line in `.gitmodules` (git does not expand variables there, so it must be edited literally), the `pwsh-src` submodule pointer on `master` (`git submodule update --remote pwsh-src && git add pwsh-src`), and the "Current pins" table in README.md.
 
 The repository uses a downstream patch branch model:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 GitHub Actions workflows for building redistributable PowerShell artifacts from upstream or downstream-patched source. The primary target is a single vendored `Devolutions.PowerShell.SDK` package, and the secondary target is a self-contained PowerShell distribution archive.
 
+## Quick start
+
+This repository builds PowerShell from source. The full PowerShell source tree is pulled in as a git submodule at `pwsh-src/`, so cloning requires submodule recursion, and on Windows it requires long-path support enabled in git.
+
+```powershell
+# Windows only: enable long paths once per machine (PowerShell source has paths > 260 chars)
+git config --global core.longpaths true
+
+# Clone with the pinned PowerShell source submodule
+git clone --recursive https://github.com/awakecoding/pwsh-distro.git
+# Or, for an existing clone:
+# git submodule update --init --recursive
+```
+
+All workflows are manual and start from the GitHub Actions **Run workflow** button (see the Workflows table below). There is no local build entrypoint; the workflows are the build.
+
+> On Linux/macOS no long-path configuration is needed. On Windows, if `core.longpaths` is not enabled, the `pwsh-src` submodule checkout will fail with `Filename too long`. The workflows set this on their Windows runners automatically.
+
 ## Current pins
 
 | Component | Version |
@@ -30,6 +48,17 @@ All workflows are manual and can be started from the GitHub Actions **Run workfl
 ## Branching model
 
 This repository follows a downstream patch branch model inspired by `Devolutions/gsudo-distro`: `master` stays downstream-only, upstream PowerShell refs are mirrored under `upstream/*`, and source patches live on `downstream/vX.Y.Z` branches based on upstream release tags. The patched source is exposed on `master` as a same-repo submodule at `pwsh-src/` pinned to a commit on `downstream/vX.Y.Z`, so workflows build the exact reviewed source tree with a single `actions/checkout` using `submodules: true`. See [BRANCHING.md](BRANCHING.md) for the full branch, tag, submodule, and worktree flow.
+
+## Updating PowerShell versions
+
+When moving to a new upstream PowerShell release, the bump touches four surfaces in the same PR:
+
+1. Workflow `env` blocks in `.github/workflows/powershell-sdk.yml` and `.github/workflows/powershell.yml`: `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF`.
+2. `.gitmodules`: the `branch = downstream/vX.Y.Z` line under `[submodule "pwsh-src"]` (git does not expand variables in `.gitmodules`, so this must be edited literally).
+3. The `pwsh-src` submodule pointer on `master`, bumped to the new `downstream/vX.Y.Z` tip with `git submodule update --remote pwsh-src && git add pwsh-src`.
+4. The "Current pins" table above.
+
+Verify the upstream target framework from `pwsh-src/PowerShell.Common.props` after the bump and keep SDK packaging paths derived from that property instead of hardcoding `net*` folders.
 
 ## Notes
 

--- a/scripts/Sync-PowerShellUpstream.ps1
+++ b/scripts/Sync-PowerShellUpstream.ps1
@@ -47,6 +47,10 @@ if (Test-GitRemote $UpstreamRemote) {
 }
 
 Invoke-Git fetch $UpstreamRemote --prune --no-tags
+# --no-tags is intentional: upstream PowerShell publishes bare vX.Y.Z tags that
+# would otherwise be fetched into refs/tags/vX.Y.Z and pollute the downstream
+# namespace. Upstream tags are mirrored only under refs/tags/upstream/* by the
+# SyncTags block below. Keep this flag whenever fetching from $UpstreamRemote.
 
 $RemoteBranchRef = "refs/remotes/$UpstreamRemote/$UpstreamBranch"
 Invoke-Git rev-parse --verify $RemoteBranchRef


### PR DESCRIPTION
## What

Makes `awakecoding/pwsh-distro` clone-and-build friendly for someone who just wants to `git clone` and run the workflows.

## Why

A fresh clone of this repo pulls in the full PowerShell source tree as a git submodule at `pwsh-src/`. That tree has paths exceeding `MAX_PATH`, so on Windows the submodule checkout fails with `Filename too long` unless `core.longpaths=true` is set. `dotnet-runtime.yml` already sets this on its Windows runner step, but neither PowerShell workflow did, so `actions/checkout` with `submodules: true` could fail on the Windows runners. The README also described the branching model in depth but never gave the one-paragraph clone-build path a newcomer expects.

This PR closes those gaps.

## Changes

- **`.github/workflows/powershell-sdk.yml`** - added an `Enable Windows long path support` step (`git config --system core.longpaths true`, gated on `runner.os == 'Windows'`) before `actions/checkout` in both the `apphost` and `build` jobs. Mirrors the pattern already in `dotnet-runtime.yml`.
- **`.github/workflows/powershell.yml`** - same long-paths step before checkout.
- **`README.md`** - new **Quick start** section (Windows long-path prereq, `git clone --recursive`, manual workflows) and an **Updating PowerShell versions** section listing the four coordinated bump surfaces including the `.gitmodules` `branch = downstream/vX.Y.Z` literal edit.
- **`AGENTS.md`** - expanded the version-bump checklist to include the `.gitmodules` branch edit and submodule pointer bump.
- **`scripts/Sync-PowerShellUpstream.ps1`** - clarifying comment on the `--no-tags` discipline so a future contributor does not simplify the refspec and reintroduce bare `vX.Y.Z` tags into local clones.

## Notes

- No remote tag cleanup is included. An earlier review suspected `upstream/vX.Y.Z` tag pollution, but investigation showed origin only carries 4 tags (all under `upstream/*`); the 98 bare `vX.Y.Z` tags seen in some local clones are local-only artifacts from fetching the `powershell` remote without `--no-tags` and were never pushed to origin. The script comment is the preventative fix.
- `downstream/v7.6.3` currently has zero downstream patches relative to `upstream/v7.6.3`; that is an intentional first cut, not a defect, and is out of scope here.

## Verification

- Both workflow files parse as valid YAML.
- `git diff --check` clean (no whitespace errors).
- Both long-paths steps land before the checkout step in every job.