### PR TITLE
Harden vendored PowerShell SDK apphost validation

### DIFF
--- a/.github/workflows/powershell-sdk.yml
+++ b/.github/workflows/powershell-sdk.yml
@@ -750,21 +750,70 @@ jobs:
 
           Pack-VendoredPackage $SdkStagePath $PackageOutputPath
 
-      - name: Validate PowerShell SDK package
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          ./eng/Validate-PowerShellSdkPackage.ps1 `
-            -PackageDirectory ./pwsh-src/package `
-            -PowerShellVersion $Env:POWERSHELL_VERSION `
-            -TargetFramework $Env:POWERSHELL_TARGET_FRAMEWORK `
-            -RuntimeIdentifier linux-x64 `
-            -PackageId $Env:SDK_PACKAGE_ID `
-            -PackageVendorName $Env:SDK_VENDOR_NAME
-
       - name: Upload PowerShell package
         uses: actions/upload-artifact@v7.0.1
         with:
           name: PowerShell-SDK-${{env.POWERSHELL_VERSION}}
           path: "pwsh-src/package/*.nupkg"
 
+  validate:
+    name: Validate PowerShell SDK [${{matrix.rid}}]
+    runs-on: ${{matrix.runner}}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            runner: windows-2025
+          - rid: linux-x64
+            runner: ubuntu-24.04
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+          - rid: osx-x64
+            runner: macos-15-intel
+          - rid: osx-arm64
+            runner: macos-15
+
+    steps:
+      - name: Enable Windows long path support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
+      - name: Clone project with PowerShell submodule
+        uses: actions/checkout@v7.0.0
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5.3.0
+        with:
+          global-json-file: pwsh-src/global.json
+
+      - name: Download PowerShell SDK package
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: PowerShell-SDK-${{env.POWERSHELL_VERSION}}
+          path: sdk-package
+
+      - name: Validate PowerShell SDK package
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          [xml]$CommonProps = Get-Content ./pwsh-src/PowerShell.Common.props
+          $TargetFramework = $CommonProps.Project.PropertyGroup |
+            ForEach-Object { $_.TargetFramework } |
+            Where-Object { $_ } |
+            Select-Object -First 1
+          if (-not $TargetFramework) {
+            throw "Unable to determine PowerShell TargetFramework from PowerShell.Common.props"
+          }
+
+          ./eng/Validate-PowerShellSdkPackage.ps1 `
+            -PackageDirectory ./sdk-package `
+            -PowerShellVersion $Env:POWERSHELL_VERSION `
+            -TargetFramework $TargetFramework `
+            -RuntimeIdentifier ${{matrix.rid}} `
+            -PackageId $Env:SDK_PACKAGE_ID `
+            -PackageVendorName $Env:SDK_VENDOR_NAME

--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@ GitHub Actions workflows for building redistributable PowerShell artifacts from 
 
 ## Quick start
 
-This repository builds PowerShell from source. The full PowerShell source tree is pulled in as a git submodule at `pwsh-src/`, so cloning requires submodule recursion, and on Windows it requires long-path support enabled in git.
+This repository builds PowerShell from source. The full PowerShell source tree is pulled in as a git submodule at `pwsh-src/`, so the checkout must initialize submodules, and on Windows it requires long-path support enabled in git.
 
 ```powershell
-# Windows only: enable long paths once per machine (PowerShell source has paths > 260 chars)
-git config --global core.longpaths true
-
-# Clone with the pinned PowerShell source submodule
-git clone --recursive https://github.com/awakecoding/pwsh-distro.git
-# Or, for an existing clone:
-# git submodule update --init --recursive
+git clone https://github.com/awakecoding/pwsh-distro.git
+cd pwsh-distro
+.\scripts\Initialize-Repository.ps1
 ```
 
-All workflows are manual and start from the GitHub Actions **Run workflow** button (see the Workflows table below). There is no local build entrypoint; the workflows are the build.
+All workflows are manual and start from the GitHub Actions **Run workflow** button (see the Workflows table below). The workflows are the authoritative release builds.
 
-> On Linux/macOS no long-path configuration is needed. On Windows, if `core.longpaths` is not enabled, the `pwsh-src` submodule checkout will fail with `Filename too long`. The workflows set this on their Windows runners automatically.
+> On Linux/macOS no long-path configuration is needed. On Windows, if `core.longpaths` is not enabled, the `pwsh-src` submodule checkout will fail with `Filename too long`. `scripts\Initialize-Repository.ps1` enables it before initializing the submodule. The workflows set this on their Windows runners automatically.
+
+To build a local, current-RID SDK package for smoke testing outside Actions:
+
+```powershell
+.\scripts\Build-LocalPowerShellSdk.ps1 -Validate
+```
+
+The local script writes under `output\local-sdk\<rid>\` and produces a single-RID validation package. The GitHub Actions SDK workflow remains the authoritative multi-RID package build.
 
 ## Current pins
 
@@ -77,5 +81,7 @@ The SDK package also includes apphost files for `win-x64`, `linux-x64`, `linux-a
 ```
 
 The package selects `$(RuntimeIdentifier)` first, then falls back to the SDK host runtime identifier. Set `PowerShellSDKAppHostRuntimeIdentifier` to override that selection explicitly. Unsupported runtime identifiers fail the build with a clear error instead of silently omitting apphost files. The apphost output is intended for running scripts with the core built-in modules from `$PSHOME/Modules`; it is not a full PowerShell distribution archive with localized resources, help content, or optional gallery modules.
+
+During NuGet packing, upstream `Microsoft.PowerShell.SDK` content file/reference metadata can emit NU5100/NU5131 package analysis warnings. The SDK workflow treats package validation as the source of truth: the generated sample must restore only the vendored PowerShell package ID, build, publish framework-dependent and self-contained outputs, execute `pwsh`, and load copied built-in modules.
 
 Generated source checkouts and build artifacts are not part of this repository.

--- a/eng/Microsoft.PowerShell.SDK.targets
+++ b/eng/Microsoft.PowerShell.SDK.targets
@@ -1,4 +1,135 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="PowerShellSDKRewriteSelfContainedRuntimeConfig"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <RuntimeConfigPath ParameterType="System.String" Required="true" />
+      <ApplicationRuntimeConfigPath ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        if (!File.Exists(RuntimeConfigPath))
+        {
+          Log.LogError("PowerShell apphost runtimeconfig was not found: {0}", RuntimeConfigPath);
+          return false;
+        }
+
+        if (!File.Exists(ApplicationRuntimeConfigPath))
+        {
+          Log.LogError("Application runtimeconfig was not found: {0}", ApplicationRuntimeConfigPath);
+          return false;
+        }
+
+        string powerShellRuntimeConfig = File.ReadAllText(RuntimeConfigPath);
+        string applicationRuntimeConfig = File.ReadAllText(ApplicationRuntimeConfigPath);
+        var includedFrameworkVersions = new Dictionary<string, string>(StringComparer.Ordinal);
+        string fallbackFrameworkVersion = null;
+        foreach (System.Text.RegularExpressions.Match match in System.Text.RegularExpressions.Regex.Matches(
+          applicationRuntimeConfig,
+          "\"name\"\\s*:\\s*\"([^\"]+)\"\\s*,\\s*\"version\"\\s*:\\s*\"([^\"]+)\"",
+          System.Text.RegularExpressions.RegexOptions.Singleline))
+        {
+          string frameworkName = match.Groups[1].Value;
+          string frameworkVersion = match.Groups[2].Value;
+          if (String.IsNullOrWhiteSpace(frameworkName) || String.IsNullOrWhiteSpace(frameworkVersion))
+          {
+            continue;
+          }
+
+          includedFrameworkVersions[frameworkName] = frameworkVersion;
+          if (fallbackFrameworkVersion == null)
+          {
+            fallbackFrameworkVersion = frameworkVersion;
+          }
+        }
+
+        if (fallbackFrameworkVersion == null)
+        {
+          Log.LogError("Application runtimeconfig includedFrameworks did not contain any framework versions: {0}", ApplicationRuntimeConfigPath);
+          return false;
+        }
+
+        var requiredFrameworkNames = new List<string>();
+        foreach (System.Text.RegularExpressions.Match match in System.Text.RegularExpressions.Regex.Matches(
+          powerShellRuntimeConfig,
+          "\"name\"\\s*:\\s*\"([^\"]+)\"",
+          System.Text.RegularExpressions.RegexOptions.Singleline))
+        {
+          string frameworkName = match.Groups[1].Value;
+          if (!String.IsNullOrWhiteSpace(frameworkName) && !requiredFrameworkNames.Contains(frameworkName))
+          {
+            requiredFrameworkNames.Add(frameworkName);
+          }
+        }
+
+        if (requiredFrameworkNames.Count == 0)
+        {
+          Log.LogMessage(MessageImportance.Low, "PowerShell apphost runtimeconfig has no framework references to rewrite: {0}", RuntimeConfigPath);
+          return true;
+        }
+
+        var includedFrameworkBuilder = new System.Text.StringBuilder();
+        includedFrameworkBuilder.Append("[");
+        foreach (string frameworkName in requiredFrameworkNames)
+        {
+          string frameworkVersion;
+          if (!includedFrameworkVersions.TryGetValue(frameworkName, out frameworkVersion))
+          {
+            frameworkVersion = fallbackFrameworkVersion;
+          }
+
+          if (includedFrameworkBuilder.Length > 1)
+          {
+            includedFrameworkBuilder.Append(",");
+          }
+
+          includedFrameworkBuilder.AppendLine();
+          includedFrameworkBuilder.Append("      {");
+          includedFrameworkBuilder.AppendLine();
+          includedFrameworkBuilder.Append("        \"name\": \"");
+          includedFrameworkBuilder.Append(frameworkName.Replace("\\", "\\\\").Replace("\"", "\\\""));
+          includedFrameworkBuilder.Append("\",");
+          includedFrameworkBuilder.AppendLine();
+          includedFrameworkBuilder.Append("        \"version\": \"");
+          includedFrameworkBuilder.Append(frameworkVersion.Replace("\\", "\\\\").Replace("\"", "\\\""));
+          includedFrameworkBuilder.Append("\"");
+          includedFrameworkBuilder.AppendLine();
+          includedFrameworkBuilder.Append("      }");
+        }
+        includedFrameworkBuilder.AppendLine();
+        includedFrameworkBuilder.Append("    ]");
+
+        string rewrittenRuntimeConfig = System.Text.RegularExpressions.Regex.Replace(
+          powerShellRuntimeConfig,
+          "\\s*\"framework\"\\s*:\\s*\\{[\\s\\S]*?\\}\\s*,",
+          "",
+          System.Text.RegularExpressions.RegexOptions.Singleline);
+        rewrittenRuntimeConfig = System.Text.RegularExpressions.Regex.Replace(
+          rewrittenRuntimeConfig,
+          "\\s*\"frameworks\"\\s*:\\s*\\[[\\s\\S]*?\\]\\s*,",
+          "",
+          System.Text.RegularExpressions.RegexOptions.Singleline);
+
+        string rewrittenWithIncludedFrameworks = System.Text.RegularExpressions.Regex.Replace(
+          rewrittenRuntimeConfig,
+          "(\"tfm\"\\s*:\\s*\"[^\"]+\"\\s*,)",
+          "$1" + Environment.NewLine + "    \"includedFrameworks\": " + includedFrameworkBuilder.ToString() + ",",
+          System.Text.RegularExpressions.RegexOptions.Singleline);
+        if (Object.ReferenceEquals(rewrittenRuntimeConfig, rewrittenWithIncludedFrameworks) || rewrittenRuntimeConfig == rewrittenWithIncludedFrameworks)
+        {
+          Log.LogError("PowerShell apphost runtimeconfig does not contain a tfm property: {0}", RuntimeConfigPath);
+          return false;
+        }
+
+        File.WriteAllText(RuntimeConfigPath, rewrittenWithIncludedFrameworks);
+        Log.LogMessage(MessageImportance.High, "Rewrote PowerShell apphost runtimeconfig for self-contained publish: {0}", RuntimeConfigPath);
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
   <PropertyGroup>
     <PowerShellSDKIncludeAppHost Condition="'$(PowerShellSDKIncludeAppHost)' == ''">false</PowerShellSDKIncludeAppHost>
   </PropertyGroup>
@@ -68,5 +199,13 @@
           Condition="'$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True'">
     <Exec Command="chmod +x &quot;$(PublishDir)pwsh&quot;"
           Condition="'$(OS)' != 'Windows_NT' and Exists('$(PublishDir)pwsh')" />
+  </Target>
+
+  <Target Name="PowerShellSDKRewriteSelfContainedPublishedRuntimeConfig"
+          AfterTargets="Publish"
+          Condition="('$(PowerShellSDKIncludeAppHost)' == 'true' or '$(PowerShellSDKIncludeAppHost)' == 'True') and ('$(SelfContained)' == 'true' or '$(SelfContained)' == 'True')">
+    <PowerShellSDKRewriteSelfContainedRuntimeConfig
+      RuntimeConfigPath="$(PublishDir)pwsh.runtimeconfig.json"
+      ApplicationRuntimeConfigPath="$(PublishDir)$(AssemblyName).runtimeconfig.json" />
   </Target>
 </Project>

--- a/eng/Validate-PowerShellSdkPackage.ps1
+++ b/eng/Validate-PowerShellSdkPackage.ps1
@@ -71,6 +71,140 @@ function Add-ProjectProperty {
   [void] $PropertyGroup.AppendChild($Element)
 }
 
+function Assert-AppHostOutput {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Directory,
+
+    [Parameter(Mandatory)]
+    [string] $ExecutableName,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json')) {
+    $OutputPath = Join-Path $Directory $FileName
+    if (-not (Test-Path $OutputPath -PathType Leaf)) {
+      throw "$Description is missing expected apphost file: $OutputPath"
+    }
+  }
+
+  foreach ($RelativeModulePath in @(
+      'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1',
+      'Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1',
+      'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1')) {
+    $OutputPath = Join-Path $Directory ($RelativeModulePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path $OutputPath -PathType Leaf)) {
+      throw "$Description is missing expected apphost module file: $OutputPath"
+    }
+  }
+}
+
+function Assert-RuntimeConfigMode {
+  param(
+    [Parameter(Mandatory)]
+    [string] $RuntimeConfigPath,
+
+    [Parameter(Mandatory)]
+    [bool] $SelfContained,
+
+    [Parameter(Mandatory)]
+    [string] $Description
+  )
+
+  $RuntimeConfig = Get-Content -LiteralPath $RuntimeConfigPath -Raw
+  if ($SelfContained) {
+    if ($RuntimeConfig -notmatch '"includedFrameworks"\s*:') {
+      throw "$Description runtimeconfig is not self-contained; missing includedFrameworks: $RuntimeConfigPath"
+    }
+    if ($RuntimeConfig -match '"frameworks?"\s*:') {
+      throw "$Description runtimeconfig still contains framework-dependent entries: $RuntimeConfigPath"
+    }
+    return
+  }
+
+  if ($RuntimeConfig -match '"includedFrameworks"\s*:') {
+    throw "$Description runtimeconfig was unexpectedly rewritten as self-contained: $RuntimeConfigPath"
+  }
+  if ($RuntimeConfig -notmatch '"frameworks?"\s*:') {
+    throw "$Description runtimeconfig does not contain framework-dependent entries: $RuntimeConfigPath"
+  }
+}
+
+function Invoke-PwshVersionCheck {
+  param(
+    [Parameter(Mandatory)]
+    [string] $PwshPath,
+
+    [Parameter(Mandatory)]
+    [string] $ExpectedVersion
+  )
+
+  $PwshOutput = & $PwshPath -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+  if ($LASTEXITCODE -ne 0) {
+    throw "$PwshPath failed with exit code $LASTEXITCODE"
+  }
+  $PwshVersion = [string] ($PwshOutput | Select-Object -Last 1)
+  if ($PwshVersion.Trim() -ne $ExpectedVersion) {
+    throw "$PwshPath reported PowerShell version '$PwshVersion', expected '$ExpectedVersion'"
+  }
+
+  return $PwshVersion.Trim()
+}
+
+function Invoke-PwshModuleProbe {
+  param(
+    [Parameter(Mandatory)]
+    [string] $PwshPath,
+
+    [Parameter(Mandatory)]
+    [string] $ModuleRoot
+  )
+
+  $PreviousPSModulePath = $Env:PSModulePath
+  $PreviousExpectedModuleRoot = $Env:PowerShellSDKExpectedModuleRoot
+  try {
+    $Env:PSModulePath = ''
+    $Env:PowerShellSDKExpectedModuleRoot = $ModuleRoot
+    $ModuleProbe = @'
+$ErrorActionPreference = 'Stop'
+$expectedModuleRoot = $env:PowerShellSDKExpectedModuleRoot
+foreach ($moduleName in 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility') {
+  $module = $null
+  foreach ($candidate in Get-Module -ListAvailable $moduleName) {
+    $module = $candidate
+    break
+  }
+  if ($null -eq $module) {
+    throw "Module '$moduleName' is not available"
+  }
+
+  if (-not $module.Path.StartsWith($expectedModuleRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Module '$moduleName' was loaded from '$($module.Path)' instead of '$expectedModuleRoot'"
+  }
+}
+
+$getProcess = Get-Command Get-Process -ErrorAction Stop
+if ($getProcess.Source -ne 'Microsoft.PowerShell.Management') {
+  throw "Get-Process resolved from '$($getProcess.Source)' instead of Microsoft.PowerShell.Management"
+}
+
+$selectObject = Get-Command Select-Object -ErrorAction Stop
+if ($selectObject.Source -ne 'Microsoft.PowerShell.Utility') {
+  throw "Select-Object resolved from '$($selectObject.Source)' instead of Microsoft.PowerShell.Utility"
+}
+'@
+    $PwshModuleProbeOutput = & $PwshPath -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $ModuleProbe
+    if ($LASTEXITCODE -ne 0) {
+      throw "$PwshPath failed module probe with exit code $LASTEXITCODE"
+    }
+  } finally {
+    $Env:PSModulePath = $PreviousPSModulePath
+    $Env:PowerShellSDKExpectedModuleRoot = $PreviousExpectedModuleRoot
+  }
+}
+
 function Read-ZipEntryText {
   param(
     [Parameter(Mandatory)]
@@ -307,21 +441,8 @@ foreach (PSObject result in ps.Invoke())
 
   $OutputDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Debug' (Join-Path $TargetFramework $RuntimeIdentifier)))
   $PwshPath = Join-Path $OutputDirectory $ExecutableName
-  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json')) {
-    $OutputPath = Join-Path $OutputDirectory $FileName
-    if (-not (Test-Path $OutputPath -PathType Leaf)) {
-      throw "Sample app output is missing expected apphost file: $OutputPath"
-    }
-  }
-  foreach ($RelativeModulePath in @(
-      'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1',
-      'Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1',
-      'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1')) {
-    $OutputPath = Join-Path $OutputDirectory ($RelativeModulePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    if (-not (Test-Path $OutputPath -PathType Leaf)) {
-      throw "Sample app output is missing expected apphost module file: $OutputPath"
-    }
-  }
+  Assert-AppHostOutput -Directory $OutputDirectory -ExecutableName $ExecutableName -Description 'Sample app output'
+  Assert-RuntimeConfigMode -RuntimeConfigPath (Join-Path $OutputDirectory 'pwsh.runtimeconfig.json') -SelfContained $false -Description 'Sample app output'
 
   $AppOutput = & dotnet run --project $ProjectPath --no-build
   if ($LASTEXITCODE -ne 0) {
@@ -336,72 +457,23 @@ foreach (PSObject result in ps.Invoke())
 
   $PublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $TargetFramework (Join-Path $RuntimeIdentifier 'publish'))))
   $PublishedPwshPath = Join-Path $PublishDirectory $ExecutableName
-  foreach ($FileName in @($ExecutableName, 'pwsh.dll', 'pwsh.runtimeconfig.json')) {
-    $PublishedPath = Join-Path $PublishDirectory $FileName
-    if (-not (Test-Path $PublishedPath -PathType Leaf)) {
-      throw "Sample publish output is missing expected apphost file: $PublishedPath"
-    }
-  }
-  foreach ($RelativeModulePath in @(
-      'Modules/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1',
-      'Modules/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1',
-      'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1')) {
-    $PublishedPath = Join-Path $PublishDirectory ($RelativeModulePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    if (-not (Test-Path $PublishedPath -PathType Leaf)) {
-      throw "Sample publish output is missing expected apphost module file: $PublishedPath"
-    }
-  }
+  Assert-AppHostOutput -Directory $PublishDirectory -ExecutableName $ExecutableName -Description 'Sample self-contained publish output'
+  Assert-RuntimeConfigMode -RuntimeConfigPath (Join-Path $PublishDirectory 'pwsh.runtimeconfig.json') -SelfContained $true -Description 'Sample self-contained publish output'
+  $PwshVersion = Invoke-PwshVersionCheck -PwshPath $PublishedPwshPath -ExpectedVersion $PowerShellVersion
+  Invoke-PwshModuleProbe -PwshPath $PublishedPwshPath -ModuleRoot (Join-Path $PublishDirectory 'Modules')
 
-  $PwshOutput = & $PublishedPwshPath -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
-  if ($LASTEXITCODE -ne 0) {
-    throw "$PublishedPwshPath failed with exit code $LASTEXITCODE"
-  }
-  $PwshVersion = [string] ($PwshOutput | Select-Object -Last 1)
-  if ($PwshVersion.Trim() -ne $PowerShellVersion) {
-    throw "$PublishedPwshPath reported PowerShell version '$PwshVersion', expected '$PowerShellVersion'"
-  }
-
-  $PreviousPSModulePath = $Env:PSModulePath
-  $PreviousExpectedModuleRoot = $Env:PowerShellSDKExpectedModuleRoot
-  try {
-    $Env:PSModulePath = ''
-    $Env:PowerShellSDKExpectedModuleRoot = Join-Path $PublishDirectory 'Modules'
-    $ModuleProbe = @'
-$ErrorActionPreference = 'Stop'
-$expectedModuleRoot = $env:PowerShellSDKExpectedModuleRoot
-foreach ($moduleName in 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility') {
-  $module = Get-Module -ListAvailable $moduleName | Select-Object -First 1
-  if ($null -eq $module) {
-    throw "Module '$moduleName' is not available"
-  }
-
-  if (-not $module.Path.StartsWith($expectedModuleRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw "Module '$moduleName' was loaded from '$($module.Path)' instead of '$expectedModuleRoot'"
-  }
-}
-
-$getProcess = Get-Command Get-Process -ErrorAction Stop
-if ($getProcess.Source -ne 'Microsoft.PowerShell.Management') {
-  throw "Get-Process resolved from '$($getProcess.Source)' instead of Microsoft.PowerShell.Management"
-}
-
-$selectObject = Get-Command Select-Object -ErrorAction Stop
-if ($selectObject.Source -ne 'Microsoft.PowerShell.Utility') {
-  throw "Select-Object resolved from '$($selectObject.Source)' instead of Microsoft.PowerShell.Utility"
-}
-'@
-    $PwshModuleProbeOutput = & $PublishedPwshPath -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command $ModuleProbe
-    if ($LASTEXITCODE -ne 0) {
-      throw "$PublishedPwshPath failed module probe with exit code $LASTEXITCODE"
-    }
-  } finally {
-    $Env:PSModulePath = $PreviousPSModulePath
-    $Env:PowerShellSDKExpectedModuleRoot = $PreviousExpectedModuleRoot
-  }
+  $FrameworkDependentPublishDirectory = Join-Path $SampleDirectory (Join-Path 'bin' (Join-Path 'Release' (Join-Path $TargetFramework (Join-Path $RuntimeIdentifier 'publish-framework-dependent'))))
+  Remove-Item $FrameworkDependentPublishDirectory -Recurse -Force -ErrorAction SilentlyContinue
+  Invoke-DotNet @('publish', $ProjectPath, '--nologo', '--verbosity', 'minimal', '-c', 'Release', '-r', $RuntimeIdentifier, '--self-contained', 'false', '-o', $FrameworkDependentPublishDirectory)
+  $FrameworkDependentPwshPath = Join-Path $FrameworkDependentPublishDirectory $ExecutableName
+  Assert-AppHostOutput -Directory $FrameworkDependentPublishDirectory -ExecutableName $ExecutableName -Description 'Sample framework-dependent publish output'
+  Assert-RuntimeConfigMode -RuntimeConfigPath (Join-Path $FrameworkDependentPublishDirectory 'pwsh.runtimeconfig.json') -SelfContained $false -Description 'Sample framework-dependent publish output'
+  [void] (Invoke-PwshVersionCheck -PwshPath $FrameworkDependentPwshPath -ExpectedVersion $PowerShellVersion)
 
   Write-Host "Validated $PackageId $PowerShellVersion from $($Package.FullName)"
   Write-Host "Sample app imported vendored PowerShell SDK $($AppVersion.Trim())"
-  Write-Host "Sample publish apphost reported PowerShell $($PwshVersion.Trim()): $PublishedPwshPath"
+  Write-Host "Sample self-contained publish apphost reported PowerShell $PwshVersion`: $PublishedPwshPath"
+  Write-Host "Sample framework-dependent publish apphost reported PowerShell $PowerShellVersion`: $FrameworkDependentPwshPath"
 } finally {
   Set-Location $PreviousLocation
   $Env:NUGET_PACKAGES = $PreviousNuGetPackages

--- a/scripts/Build-LocalPowerShellSdk.ps1
+++ b/scripts/Build-LocalPowerShellSdk.ps1
@@ -1,0 +1,469 @@
+[CmdletBinding()]
+param(
+  [string] $PowerShellVersion = '7.6.3',
+
+  [string] $PowerShellReleaseTag = 'v7.6.3',
+
+  [string] $PackageId = 'Devolutions.PowerShell.SDK',
+
+  [string] $VendorName = 'Devolutions',
+
+  [string] $MultiPwshPackageId = 'Devolutions.MultiPwsh.Cli',
+
+  [string] $MultiPwshPackageVersion = '0.14.0',
+
+  [string] $MultiPwshPackageSource = 'https://api.nuget.org/v3/index.json',
+
+  [string] $RuntimeIdentifier,
+
+  [string] $OutputRoot = 'output\local-sdk',
+
+  [string] $NuGetExe,
+
+  [switch] $Validate
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory)]
+    [string] $FilePath,
+
+    [string[]] $Arguments
+  )
+
+  & $FilePath @Arguments | ForEach-Object { Write-Host $_ }
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Invoke-GitOutput {
+  param(
+    [Parameter(Mandatory, ValueFromRemainingArguments)]
+    [string[]] $Arguments
+  )
+
+  $Output = & git @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+
+  return $Output
+}
+
+function Get-DefaultRuntimeIdentifier {
+  $Architecture = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
+    'X64' { 'x64'; break }
+    'Arm64' { 'arm64'; break }
+    default { throw "Unsupported architecture for local SDK build: $_" }
+  }
+
+  if ($IsWindows) {
+    return "win-$Architecture"
+  }
+  if ($IsLinux) {
+    return "linux-$Architecture"
+  }
+  if ($IsMacOS) {
+    return "osx-$Architecture"
+  }
+
+  throw 'Unsupported operating system for local SDK build.'
+}
+
+function Get-PSBuildRuntime {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Rid
+  )
+
+  switch ($Rid) {
+    'win-x64' { return 'fxdependent-win-desktop' }
+    'linux-x64' { return 'fxdependent-linux-x64' }
+    'linux-arm64' { return 'fxdependent-linux-arm64' }
+    'osx-x64' { return 'fxdependent' }
+    'osx-arm64' { return 'fxdependent' }
+    default { throw "Unsupported local SDK runtime identifier: $Rid" }
+  }
+}
+
+function ConvertTo-XmlAttributeValue {
+  param(
+    [AllowNull()]
+    [string] $Value
+  )
+
+  if ($null -eq $Value) {
+    return ''
+  }
+
+  return [System.Security.SecurityElement]::Escape($Value)
+}
+
+function Get-NuGetCommand {
+  param(
+    [Parameter(Mandatory)]
+    [string] $ToolDirectory
+  )
+
+  if ($NuGetExe) {
+    $ResolvedNuGetExe = (Resolve-Path -LiteralPath $NuGetExe).Path
+    if (-not (Test-Path -LiteralPath $ResolvedNuGetExe -PathType Leaf)) {
+      throw "NuGet CLI was not found at $ResolvedNuGetExe"
+    }
+
+    return $ResolvedNuGetExe
+  }
+
+  $NuGetCommand = Get-Command nuget -ErrorAction SilentlyContinue
+  if ($NuGetCommand) {
+    return $NuGetCommand.Source
+  }
+
+  if (-not $IsWindows) {
+    throw 'NuGet CLI was not found on PATH. Install nuget, or pass -NuGetExe.'
+  }
+
+  New-Item -Path $ToolDirectory -ItemType Directory -Force | Out-Null
+  $DownloadedNuGetExe = Join-Path $ToolDirectory 'nuget.exe'
+  if (-not (Test-Path -LiteralPath $DownloadedNuGetExe -PathType Leaf)) {
+    Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $DownloadedNuGetExe
+  }
+
+  return $DownloadedNuGetExe
+}
+
+function Resolve-MultiPwshAppHostAsset {
+  param(
+    [Parameter(Mandatory)]
+    [string] $TargetFramework,
+
+    [Parameter(Mandatory)]
+    [string] $Rid
+  )
+
+  $ResolveRoot = Join-Path ([System.IO.Path]::GetTempPath()) "multi-pwsh-apphost-resolve-$([Guid]::NewGuid().ToString('N'))"
+  $ProjectPath = Join-Path $ResolveRoot 'MultiPwshAppHostResolver.csproj'
+  $NuGetConfigPath = Join-Path $ResolveRoot 'nuget.config'
+  $AssetListPath = Join-Path $ResolveRoot 'multi-pwsh-apphost-assets.tsv'
+  $InfoPath = Join-Path $ResolveRoot 'multi-pwsh-apphost-info.txt'
+
+  New-Item $ResolveRoot -ItemType Directory -Force | Out-Null
+  try {
+    $PackageSourceXml = ConvertTo-XmlAttributeValue $MultiPwshPackageSource
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="multiPwsh" value="$PackageSourceXml" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -Path $NuGetConfigPath -Encoding utf8
+
+    $PackageIdXml = ConvertTo-XmlAttributeValue $MultiPwshPackageId
+    $PackageVersionXml = ConvertTo-XmlAttributeValue $MultiPwshPackageVersion
+    $TargetFrameworkXml = ConvertTo-XmlAttributeValue $TargetFramework
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$TargetFrameworkXml</TargetFramework>
+    <MultiPwshRuntimeNativeContentCopyEnabled>false</MultiPwshRuntimeNativeContentCopyEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="$PackageIdXml" Version="$PackageVersionXml" PrivateAssets="all" GeneratePathProperty="true" />
+  </ItemGroup>
+  <Target Name="WriteMultiPwshAppHostAssets" DependsOnTargets="ResolveMultiPwshAppHostAssets">
+    <WriteLinesToFile File="`$(MultiPwshAppHostAssetOutputPath)"
+                      Lines="@(MultiPwshAppHostAsset->'%(RuntimeIdentifier)|%(NativeFileName)|%(AppHostFileName)|%(PackageRelativePath)|%(PackageId)|%(FullPath)')"
+                      Overwrite="true" />
+    <WriteLinesToFile File="`$(MultiPwshAppHostInfoPath)"
+                      Lines="PackageRoot=`$(PkgDevolutions_MultiPwsh_Cli)|ManifestPath=`$(MultiPwshAppHostManifestPath)"
+                      Overwrite="true" />
+  </Target>
+</Project>
+"@ | Set-Content -Path $ProjectPath -Encoding utf8
+
+    Invoke-Native dotnet @('restore', $ProjectPath, '--configfile', $NuGetConfigPath, '--verbosity', 'minimal')
+    Invoke-Native dotnet @('msbuild', $ProjectPath, '-nologo', '-v:minimal', '-t:WriteMultiPwshAppHostAssets', "/p:MultiPwshAppHostAssetOutputPath=$AssetListPath", "/p:MultiPwshAppHostInfoPath=$InfoPath")
+
+    $PackageInfo = @{}
+    if (Test-Path $InfoPath -PathType Leaf) {
+      foreach ($InfoField in ((Get-Content -LiteralPath $InfoPath -Raw) -split '\|')) {
+        $Pair = $InfoField -split '=', 2
+        if ($Pair.Count -eq 2) {
+          $PackageInfo[$Pair[0]] = $Pair[1].Trim()
+        }
+      }
+    }
+
+    foreach ($Line in Get-Content -LiteralPath $AssetListPath) {
+      if ([string]::IsNullOrWhiteSpace($Line)) {
+        continue
+      }
+
+      $Fields = $Line -split '\|', 6
+      if ($Fields.Count -ne 6) {
+        throw "Unexpected multi-pwsh apphost asset record: $Line"
+      }
+      if ($Fields[0] -ne $Rid) {
+        continue
+      }
+      if ($Fields[4] -ne $MultiPwshPackageId) {
+        throw "Resolved apphost from package '$($Fields[4])', expected '$MultiPwshPackageId'"
+      }
+
+      $SourcePath = $Fields[5]
+      if ([string]::IsNullOrWhiteSpace($SourcePath) -or -not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) {
+        $PackageRoot = $PackageInfo['PackageRoot']
+        if (-not [string]::IsNullOrWhiteSpace($PackageRoot) -and -not [string]::IsNullOrWhiteSpace($Fields[3])) {
+          $SourcePath = Join-Path $PackageRoot ($Fields[3] -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        }
+      }
+      if (-not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) {
+        throw "Resolved apphost asset for '$Rid' does not exist at '$SourcePath'"
+      }
+
+      return [pscustomobject]@{
+        RuntimeIdentifier = $Fields[0]
+        AppHostFileName = $Fields[2]
+        SourcePath = $SourcePath
+      }
+    }
+
+    throw "No $MultiPwshPackageId apphost asset found for '$Rid'."
+  } finally {
+    Remove-Item $ResolveRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Add-OverlayFile {
+  param(
+    [Parameter(Mandatory)]
+    [hashtable] $OverlayPathMap,
+
+    [Parameter(Mandatory)]
+    [string] $PackageRelativePath,
+
+    [Parameter(Mandatory)]
+    [string] $SourcePath,
+
+    [bool] $Required = $true
+  )
+
+  if (Test-Path $SourcePath -PathType Leaf) {
+    $OverlayPathMap[$PackageRelativePath] = $SourcePath
+    return
+  }
+
+  if ($Required) {
+    throw "Missing source-built package file for $PackageRelativePath`: $SourcePath"
+  }
+}
+
+if (-not $RuntimeIdentifier) {
+  $RuntimeIdentifier = Get-DefaultRuntimeIdentifier
+}
+
+$RepositoryRoot = (Invoke-GitOutput rev-parse --show-toplevel | Select-Object -First 1).Trim()
+if (-not $RepositoryRoot) {
+  throw 'Unable to determine git repository root.'
+}
+
+$RepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$PwshSourceRoot = Join-Path $RepositoryRoot 'pwsh-src'
+if (-not (Test-Path (Join-Path $PwshSourceRoot 'PowerShell.Common.props') -PathType Leaf)) {
+  throw 'pwsh-src is not initialized. Run scripts\Initialize-Repository.ps1 first.'
+}
+
+$OutputRootPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Join-Path $RepositoryRoot (Join-Path $OutputRoot $RuntimeIdentifier)))
+$AppHostOutputPath = Join-Path $OutputRootPath 'PowerShell-AppHost'
+$PackageRuntimePath = Join-Path $OutputRootPath 'package-runtime'
+$PackageOutputPath = Join-Path $OutputRootPath 'package'
+$PackageStageRoot = Join-Path $OutputRootPath 'nupkg-stage'
+
+Remove-Item $OutputRootPath -Recurse -Force -ErrorAction SilentlyContinue
+New-Item $OutputRootPath, $PackageRuntimePath, $PackageOutputPath, $PackageStageRoot -ItemType Directory -Force | Out-Null
+$NuGetCommand = Get-NuGetCommand -ToolDirectory (Join-Path $OutputRootPath 'tools')
+$env:PATH = "$(Split-Path -Parent $NuGetCommand);$env:PATH"
+
+$ModuleNugetConfigPath = Join-Path $PwshSourceRoot 'src\Modules\nuget.config'
+$HadModuleNugetConfig = Test-Path $ModuleNugetConfigPath -PathType Leaf
+$OriginalModuleNugetConfig = if ($HadModuleNugetConfig) { Get-Content -LiteralPath $ModuleNugetConfigPath -Raw } else { $null }
+
+Push-Location $PwshSourceRoot
+try {
+  Import-Module .\build.psm1 -Force
+  Start-PSBootstrap -Scenario DotNet
+  if ($IsWindows) {
+    Switch-PSNugetConfig -Source Public
+    $ModuleNugetConfig = @(
+      '<?xml version="1.0" encoding="utf-8"?>',
+      '<configuration>',
+      '  <packageSources>',
+      '    <clear />',
+      '    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />',
+      '  </packageSources>',
+      '  <disabledPackageSources>',
+      '    <clear />',
+      '  </disabledPackageSources>',
+      '</configuration>'
+    )
+    Set-Content -Path $ModuleNugetConfigPath -Value $ModuleNugetConfig -Encoding utf8
+  }
+
+  [xml] $CommonProps = Get-Content .\PowerShell.Common.props
+  $TargetFramework = $CommonProps.Project.PropertyGroup |
+    ForEach-Object { $_.TargetFramework } |
+    Where-Object { $_ } |
+    Select-Object -First 1
+  if (-not $TargetFramework) {
+    throw 'Unable to determine PowerShell TargetFramework from PowerShell.Common.props'
+  }
+
+  $RuntimeGroup = if ($RuntimeIdentifier -like 'win-*') { 'win' } else { 'unix' }
+  $ExecutableName = if ($RuntimeIdentifier -like 'win-*') { 'pwsh.exe' } else { 'pwsh' }
+  $AppHostAsset = Resolve-MultiPwshAppHostAsset -TargetFramework $TargetFramework -Rid $RuntimeIdentifier
+
+  $PSBuildParams = @{
+    Configuration = 'Release'
+    Runtime = Get-PSBuildRuntime -Rid $RuntimeIdentifier
+    Output = $AppHostOutputPath
+    Clean = $true
+    ReleaseTag = $PowerShellReleaseTag
+    NoPSModuleRestore = $true
+    SkipExperimentalFeatureGeneration = $true
+  }
+  if (-not $IsWindows) {
+    $PSBuildParams.UseNuGetOrg = $true
+  }
+  Start-PSBuild @PSBuildParams
+
+  Invoke-Native dotnet @('build', '.\src\Microsoft.PowerShell.SDK\Microsoft.PowerShell.SDK.csproj', '-c', 'Release', "/p:ReleaseTag=$PowerShellVersion")
+
+  $CommonAssemblyDefinitions = @(
+    @{ AssemblyName = 'Microsoft.PowerShell.SDK'; ProjectDirectory = 'Microsoft.PowerShell.SDK' },
+    @{ AssemblyName = 'System.Management.Automation'; ProjectDirectory = 'System.Management.Automation' },
+    @{ AssemblyName = 'Microsoft.PowerShell.Commands.Management'; ProjectDirectory = 'Microsoft.PowerShell.Commands.Management' },
+    @{ AssemblyName = 'Microsoft.PowerShell.Commands.Utility'; ProjectDirectory = 'Microsoft.PowerShell.Commands.Utility' },
+    @{ AssemblyName = 'Microsoft.PowerShell.ConsoleHost'; ProjectDirectory = 'Microsoft.PowerShell.ConsoleHost' },
+    @{ AssemblyName = 'Microsoft.PowerShell.Security'; ProjectDirectory = 'Microsoft.PowerShell.Security' }
+  )
+  $WindowsAssemblyDefinitions = @(
+    @{ AssemblyName = 'Microsoft.PowerShell.Commands.Diagnostics'; ProjectDirectory = 'Microsoft.PowerShell.Commands.Diagnostics' },
+    @{ AssemblyName = 'Microsoft.Management.Infrastructure.CimCmdlets'; ProjectDirectory = 'Microsoft.Management.Infrastructure.CimCmdlets' },
+    @{ AssemblyName = 'Microsoft.WSMan.Management'; ProjectDirectory = 'Microsoft.WSMan.Management' },
+    @{ AssemblyName = 'Microsoft.PowerShell.CoreCLR.Eventing'; ProjectDirectory = 'Microsoft.PowerShell.CoreCLR.Eventing' },
+    @{ AssemblyName = 'Microsoft.WSMan.Runtime'; ProjectDirectory = 'Microsoft.WSMan.Runtime' }
+  )
+  $AssemblyDefinitions = if ($RuntimeGroup -eq 'win') { $CommonAssemblyDefinitions + $WindowsAssemblyDefinitions } else { $CommonAssemblyDefinitions }
+
+  foreach ($AssemblyDefinition in $AssemblyDefinitions) {
+    $AssemblyName = $AssemblyDefinition.AssemblyName
+    $SourceDirectory = if ($AssemblyName -eq 'Microsoft.PowerShell.SDK') {
+      Join-Path $PwshSourceRoot "src\$($AssemblyDefinition.ProjectDirectory)\bin\Release\$TargetFramework"
+    } else {
+      $AppHostOutputPath
+    }
+    $AssemblyPath = Join-Path $SourceDirectory "$AssemblyName.dll"
+    if (-not (Test-Path $AssemblyPath -PathType Leaf)) {
+      throw "PowerShell build did not produce package runtime assembly: $AssemblyPath"
+    }
+    Copy-Item $AssemblyPath $PackageRuntimePath -Force
+    $XmlPath = [System.IO.Path]::ChangeExtension($AssemblyPath, '.xml')
+    if (Test-Path $XmlPath -PathType Leaf) {
+      Copy-Item $XmlPath $PackageRuntimePath -Force
+    }
+  }
+
+  $SdkStagePath = Join-Path $PackageStageRoot $PackageId
+  $SdkOverlayPathMap = @{}
+  foreach ($AssemblyDefinition in $AssemblyDefinitions) {
+    $AssemblyName = $AssemblyDefinition.AssemblyName
+    $LocalAssemblyPath = Join-Path $PwshSourceRoot "src\$($AssemblyDefinition.ProjectDirectory)\bin\Release\$TargetFramework"
+    $RefSourcePath = Join-Path $LocalAssemblyPath "$AssemblyName.dll"
+    if (-not (Test-Path $RefSourcePath -PathType Leaf)) {
+      $RefSourcePath = Join-Path $PackageRuntimePath "$AssemblyName.dll"
+    }
+
+    Add-OverlayFile $SdkOverlayPathMap "ref/$TargetFramework/$AssemblyName.dll" $RefSourcePath
+    Add-OverlayFile $SdkOverlayPathMap "ref/$TargetFramework/$AssemblyName.xml" ([System.IO.Path]::ChangeExtension($RefSourcePath, '.xml')) $false
+    Add-OverlayFile $SdkOverlayPathMap "runtimes/$RuntimeGroup/lib/$TargetFramework/$AssemblyName.dll" (Join-Path $PackageRuntimePath "$AssemblyName.dll")
+  }
+
+  & (Join-Path $RepositoryRoot 'eng\Vendor-PowerShellSdkPackage.ps1') `
+    -PackageRoot $SdkStagePath `
+    -PowerShellVersion $PowerShellVersion `
+    -PackageId $PackageId `
+    -VendorName $VendorName `
+    -OverlayPathMap $SdkOverlayPathMap
+
+  $AnyAnyRuntimesDir = Join-Path $SdkStagePath 'contentFiles\any\any\runtimes'
+  Remove-Item $AnyAnyRuntimesDir -Recurse -Force -ErrorAction SilentlyContinue
+  New-Item $AnyAnyRuntimesDir -ItemType Directory -Force | Out-Null
+  $ModuleSourceRoot = if ($RuntimeGroup -eq 'win') { '.\src\Modules\Windows' } else { '.\src\Modules\Unix' }
+  Get-Item "$ModuleSourceRoot\*\*.ps*" | ForEach-Object {
+    $ModuleName = Split-Path (Split-Path $_.FullName -Parent) -Leaf
+    $DestinationDir = Join-Path $AnyAnyRuntimesDir "$RuntimeGroup\lib\$TargetFramework\Modules\$ModuleName"
+    New-Item $DestinationDir -ItemType Directory -Force | Out-Null
+    Copy-Item $_ $DestinationDir -Force
+  }
+
+  $AppHostPackageRoot = Join-Path $SdkStagePath "tools\apphost\$RuntimeIdentifier"
+  New-Item $AppHostPackageRoot -ItemType Directory -Force | Out-Null
+  Copy-Item -LiteralPath $AppHostAsset.SourcePath -Destination (Join-Path $AppHostPackageRoot $AppHostAsset.AppHostFileName) -Force
+  foreach ($FileName in @('pwsh.dll', 'pwsh.runtimeconfig.json')) {
+    $SourcePath = Join-Path $AppHostOutputPath $FileName
+    if (-not (Test-Path $SourcePath -PathType Leaf)) {
+      throw "Missing apphost file: $SourcePath"
+    }
+    Copy-Item $SourcePath $AppHostPackageRoot -Force
+  }
+  if ($AppHostAsset.AppHostFileName -ne $ExecutableName) {
+    throw "Resolved apphost file '$($AppHostAsset.AppHostFileName)' for '$RuntimeIdentifier', expected '$ExecutableName'"
+  }
+
+  $BuildTransitivePath = Join-Path $SdkStagePath 'buildTransitive'
+  New-Item $BuildTransitivePath -ItemType Directory -Force | Out-Null
+  Copy-Item (Join-Path $RepositoryRoot 'eng\Microsoft.PowerShell.SDK.targets') (Join-Path $BuildTransitivePath "$PackageId.targets") -Force
+
+  Push-Location $SdkStagePath
+  try {
+    Invoke-Native $NuGetCommand @('pack', '-OutputDirectory', $PackageOutputPath, '-NonInteractive')
+  } finally {
+    Pop-Location
+  }
+
+  $Package = Get-ChildItem -LiteralPath $PackageOutputPath -Filter "$PackageId.$PowerShellVersion*.nupkg" |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+  if (-not $Package) {
+    throw "Failed to create $PackageId.$PowerShellVersion package in $PackageOutputPath"
+  }
+
+  if ($Validate) {
+    & (Join-Path $RepositoryRoot 'eng\Validate-PowerShellSdkPackage.ps1') `
+      -PackageDirectory $PackageOutputPath `
+      -PowerShellVersion $PowerShellVersion `
+      -TargetFramework $TargetFramework `
+      -RuntimeIdentifier $RuntimeIdentifier `
+      -PackageId $PackageId `
+      -PackageVendorName $VendorName
+  }
+
+  Write-Output "Package=$($Package.FullName)"
+  Write-Output "RuntimeIdentifier=$RuntimeIdentifier"
+  Write-Output "TargetFramework=$TargetFramework"
+} finally {
+  if ($IsWindows) {
+    if ($HadModuleNugetConfig) {
+      Set-Content -Path $ModuleNugetConfigPath -Value $OriginalModuleNugetConfig -Encoding utf8NoBOM
+    } else {
+      Remove-Item $ModuleNugetConfigPath -Force -ErrorAction SilentlyContinue
+    }
+  }
+  Pop-Location
+}

--- a/scripts/Initialize-Repository.ps1
+++ b/scripts/Initialize-Repository.ps1
@@ -1,0 +1,135 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [string] $SubmodulePath = 'pwsh-src',
+
+  [ValidateSet('Local', 'Global', 'Both', 'None')]
+  [string] $LongPathScope = 'Both'
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+  param(
+    [Parameter(Mandatory, ValueFromRemainingArguments)]
+    [string[]] $Arguments
+  )
+
+  & git @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Get-GitOutput {
+  param(
+    [Parameter(Mandatory, ValueFromRemainingArguments)]
+    [string[]] $Arguments
+  )
+
+  $Output = & git @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+
+  return $Output
+}
+
+function Test-WindowsPlatform {
+  return [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    [System.Runtime.InteropServices.OSPlatform]::Windows)
+}
+
+function Set-GitLongPaths {
+  param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Local', 'Global', 'Both')]
+    [string] $Scope
+  )
+
+  $Scopes = if ($Scope -eq 'Both') { @('Local', 'Global') } else { @($Scope) }
+  foreach ($ConfigScope in $Scopes) {
+    $Arguments = if ($ConfigScope -eq 'Global') {
+      @('config', '--global', 'core.longpaths', 'true')
+    } else {
+      @('config', 'core.longpaths', 'true')
+    }
+
+    if ($PSCmdlet.ShouldProcess("$ConfigScope git config", 'Set core.longpaths=true')) {
+      Invoke-Git @Arguments
+    }
+  }
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+  throw 'git was not found on PATH.'
+}
+
+$RepositoryRoot = (Get-GitOutput rev-parse --show-toplevel | Select-Object -First 1).Trim()
+if (-not $RepositoryRoot) {
+  throw 'Unable to determine git repository root.'
+}
+
+$PreviousLocation = Get-Location
+try {
+  Set-Location $RepositoryRoot
+
+  if (-not (Test-Path '.gitmodules' -PathType Leaf)) {
+    throw "No .gitmodules file was found in $RepositoryRoot."
+  }
+
+  if (Test-WindowsPlatform) {
+    if ($LongPathScope -ne 'None') {
+      Set-GitLongPaths -Scope $LongPathScope
+    }
+
+    $LongPaths = (& git config --bool --get core.longpaths 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $LongPaths -ne 'true') {
+      throw "core.longpaths is not enabled for this repository. Re-run with -LongPathScope Local, Global, or Both."
+    }
+  }
+
+  if ($PSCmdlet.ShouldProcess($SubmodulePath, 'Synchronize submodule URL configuration')) {
+    Invoke-Git submodule sync --recursive -- $SubmodulePath
+  }
+
+  if ($PSCmdlet.ShouldProcess($SubmodulePath, 'Initialize and update submodule to the pinned commit')) {
+    Invoke-Git submodule update --init --recursive -- $SubmodulePath
+  }
+
+  $SubmoduleStatus = @(Get-GitOutput submodule status --recursive -- $SubmodulePath)
+  foreach ($Line in $SubmoduleStatus) {
+    if ($Line.StartsWith('-')) {
+      throw "Submodule is not initialized: $Line"
+    }
+    if ($Line.StartsWith('+')) {
+      throw "Submodule checkout does not match the pinned commit: $Line"
+    }
+    if ($Line.StartsWith('U')) {
+      throw "Submodule has unresolved conflicts: $Line"
+    }
+  }
+
+  $CommonPropsPath = Join-Path $SubmodulePath 'PowerShell.Common.props'
+  if (-not (Test-Path $CommonPropsPath -PathType Leaf)) {
+    throw "PowerShell source submodule did not initialize correctly; missing $CommonPropsPath."
+  }
+
+  [xml] $CommonProps = Get-Content -LiteralPath $CommonPropsPath
+  $TargetFramework = $CommonProps.Project.PropertyGroup |
+    ForEach-Object { $_.TargetFramework } |
+    Where-Object { $_ } |
+    Select-Object -First 1
+
+  $SubmoduleCommit = (Get-GitOutput @('-C', $SubmodulePath, 'rev-parse', 'HEAD') | Select-Object -First 1).Trim()
+
+  Write-Output "RepositoryRoot=$RepositoryRoot"
+  if (Test-WindowsPlatform) {
+    Write-Output "GitCoreLongPaths=$((& git config --bool --get core.longpaths).Trim())"
+  }
+  Write-Output "SubmodulePath=$SubmodulePath"
+  Write-Output "SubmoduleCommit=$SubmoduleCommit"
+  Write-Output "PowerShellTargetFramework=$TargetFramework"
+} finally {
+  Set-Location $PreviousLocation
+}


### PR DESCRIPTION
## Summary
- add repository initialization and local SDK build scripts for submodule setup and single-RID SDK smoke builds
- fix self-contained publish apphost startup by rewriting only the published `pwsh.runtimeconfig.json`
- expand SDK package validation into a runtime matrix and validate both self-contained and framework-dependent publish outputs
- document local build usage and expected NuGet pack warning posture

## Validation
- `pwsh -NoLogo -NoProfile -Command "[scriptblock]::Create((Get-Content -LiteralPath '.\scripts\Build-LocalPowerShellSdk.ps1' -Raw)) | Out-Null; [scriptblock]::Create((Get-Content -LiteralPath '.\eng\Validate-PowerShellSdkPackage.ps1' -Raw)) | Out-Null; [scriptblock]::Create((Get-Content -LiteralPath '.\scripts\Initialize-Repository.ps1' -Raw)) | Out-Null; [xml](Get-Content -LiteralPath '.\eng\Microsoft.PowerShell.SDK.targets' -Raw) | Out-Null; 'syntax ok'"`
- `git diff --check`
- `.\scripts\Build-LocalPowerShellSdk.ps1 -RuntimeIdentifier win-x64 -Validate`