### PR TITLE
Add agent skill symlinks

### DIFF
--- a/.agents/skills/powershell-pin-audit/SKILL.md
+++ b/.agents/skills/powershell-pin-audit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: powershell-pin-audit
+description: Audits coordinated PowerShell version pins across workflows, .gitmodules, README.md, and the checked-out upstream PowerShell target framework.
+---
+
+# powershell pin audit
+
+Use this skill when updating the pinned PowerShell version, reviewing a PowerShell release bump, or checking that the repository's coordinated PowerShell pins still agree.
+
+The audit checks the primary `.github/workflows/powershell-sdk.yml` workflow, the secondary `.github/workflows/powershell.yml` workflow, `.gitmodules`, the README "Current pins" table, and `pwsh-src/PowerShell.Common.props` when the submodule is available.
+
+## Prerequisites
+
+- PowerShell 7 (`pwsh`).
+- Initialize `pwsh-src/` before release-bump validation if you need target-framework verification.
+
+## Usage
+
+Run the default audit from the repository root:
+
+```powershell
+pwsh .\.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1
+```
+
+Require the `pwsh-src/` submodule and fail if `PowerShell.Common.props` is unavailable:
+
+```powershell
+pwsh .\.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1 -RequireSubmodule
+```
+
+Audit a different checkout:
+
+```powershell
+pwsh .\.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1 -RepositoryRoot D:\dev\pwsh-distro
+```
+
+## Checks
+
+- `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF` are present in both PowerShell workflows.
+- The two workflows use the same PowerShell pin values.
+- `POWERSHELL_RELEASE_TAG` is `v$POWERSHELL_VERSION`.
+- `POWERSHELL_UPSTREAM_TAG` is `upstream/$POWERSHELL_RELEASE_TAG`.
+- `POWERSHELL_SOURCE_REF` is `downstream/$POWERSHELL_RELEASE_TAG`.
+- `.gitmodules` tracks the same downstream branch as `POWERSHELL_SOURCE_REF`.
+- README "Current pins" records the same upstream release, downstream source ref, upstream base tag, and target framework.
+- If `pwsh-src/PowerShell.Common.props` exists, README's target framework matches its `<TargetFramework>` value.

--- a/.agents/skills/powershell-pin-audit/scripts/Test-PowerShellPins.ps1
+++ b/.agents/skills/powershell-pin-audit/scripts/Test-PowerShellPins.ps1
@@ -1,0 +1,185 @@
+[CmdletBinding()]
+param(
+  [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path,
+
+  [switch] $RequireSubmodule
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$RepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$Errors = [System.Collections.Generic.List[string]]::new()
+$Warnings = [System.Collections.Generic.List[string]]::new()
+
+function Add-AuditError {
+  param([Parameter(Mandatory)][string] $Message)
+  $Errors.Add($Message) | Out-Null
+}
+
+function Add-AuditWarning {
+  param([Parameter(Mandatory)][string] $Message)
+  $Warnings.Add($Message) | Out-Null
+}
+
+function Get-RepositoryFileText {
+  param([Parameter(Mandatory)][string] $RelativePath)
+
+  $Path = Join-Path $RepositoryRoot $RelativePath
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Required file '$RelativePath' was not found."
+  }
+
+  return Get-Content -Raw -LiteralPath $Path
+}
+
+function Get-RequiredRegexValue {
+  param(
+    [Parameter(Mandatory)][string] $Text,
+    [Parameter(Mandatory)][string] $Pattern,
+    [Parameter(Mandatory)][string] $Description
+  )
+
+  $Match = [regex]::Match($Text, $Pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+  if (-not $Match.Success) {
+    throw "Unable to find $Description."
+  }
+
+  return $Match.Groups[1].Value.Trim()
+}
+
+function Get-YamlScalar {
+  param(
+    [Parameter(Mandatory)][string] $Text,
+    [Parameter(Mandatory)][string] $Name,
+    [Parameter(Mandatory)][string] $FileName
+  )
+
+  $EscapedName = [regex]::Escape($Name)
+  return Get-RequiredRegexValue `
+    -Text $Text `
+    -Pattern "^\s*$EscapedName\s*:\s*['""]?([^'""\r\n]+)['""]?\s*$" `
+    -Description "$Name in $FileName"
+}
+
+function Get-PowerShellWorkflowPins {
+  param([Parameter(Mandatory)][string] $RelativePath)
+
+  $Text = Get-RepositoryFileText $RelativePath
+  $Pins = [ordered]@{}
+  foreach ($Name in @(
+    'POWERSHELL_VERSION',
+    'POWERSHELL_RELEASE_TAG',
+    'POWERSHELL_UPSTREAM_TAG',
+    'POWERSHELL_SOURCE_REF'
+  )) {
+    $Pins[$Name] = Get-YamlScalar -Text $Text -Name $Name -FileName $RelativePath
+  }
+
+  return $Pins
+}
+
+function Assert-Equal {
+  param(
+    [Parameter(Mandatory)][string] $Actual,
+    [Parameter(Mandatory)][string] $Expected,
+    [Parameter(Mandatory)][string] $Description
+  )
+
+  if ($Actual -ne $Expected) {
+    Add-AuditError "$Description expected '$Expected' but found '$Actual'."
+  }
+}
+
+$SdkWorkflow = '.github\workflows\powershell-sdk.yml'
+$DistributionWorkflow = '.github\workflows\powershell.yml'
+$SdkPins = Get-PowerShellWorkflowPins $SdkWorkflow
+$DistributionPins = Get-PowerShellWorkflowPins $DistributionWorkflow
+
+foreach ($Name in $SdkPins.Keys) {
+  Assert-Equal `
+    -Actual $DistributionPins[$Name] `
+    -Expected $SdkPins[$Name] `
+    -Description "$Name in $DistributionWorkflow"
+}
+
+$Version = $SdkPins['POWERSHELL_VERSION']
+$ReleaseTag = $SdkPins['POWERSHELL_RELEASE_TAG']
+$UpstreamTag = $SdkPins['POWERSHELL_UPSTREAM_TAG']
+$SourceRef = $SdkPins['POWERSHELL_SOURCE_REF']
+
+Assert-Equal -Actual $ReleaseTag -Expected "v$Version" -Description 'POWERSHELL_RELEASE_TAG'
+Assert-Equal -Actual $UpstreamTag -Expected "upstream/$ReleaseTag" -Description 'POWERSHELL_UPSTREAM_TAG'
+Assert-Equal -Actual $SourceRef -Expected "downstream/$ReleaseTag" -Description 'POWERSHELL_SOURCE_REF'
+
+$GitmodulesText = Get-RepositoryFileText '.gitmodules'
+$GitmodulesBranch = Get-RequiredRegexValue `
+  -Text $GitmodulesText `
+  -Pattern '^\s*branch\s*=\s*(\S+)\s*$' `
+  -Description 'pwsh-src branch in .gitmodules'
+Assert-Equal -Actual $GitmodulesBranch -Expected $SourceRef -Description 'pwsh-src branch in .gitmodules'
+
+$ReadmeText = Get-RepositoryFileText 'README.md'
+$ReadmeReleaseMatch = [regex]::Match(
+  $ReadmeText,
+  'PowerShell upstream release \| `([^`]+)` / `([^`]+)`',
+  [System.Text.RegularExpressions.RegexOptions]::Multiline)
+if ($ReadmeReleaseMatch.Success) {
+  Assert-Equal -Actual $ReadmeReleaseMatch.Groups[1].Value -Expected $Version -Description 'README PowerShell upstream release version'
+  Assert-Equal -Actual $ReadmeReleaseMatch.Groups[2].Value -Expected $ReleaseTag -Description 'README PowerShell upstream release tag'
+} else {
+  Add-AuditError 'README Current pins table is missing the PowerShell upstream release row.'
+}
+
+$ReadmeSourceMatch = [regex]::Match(
+  $ReadmeText,
+  'PowerShell downstream source ref \| `([^`]+)` based on `([^`]+)`',
+  [System.Text.RegularExpressions.RegexOptions]::Multiline)
+if ($ReadmeSourceMatch.Success) {
+  Assert-Equal -Actual $ReadmeSourceMatch.Groups[1].Value -Expected $SourceRef -Description 'README PowerShell downstream source ref'
+  Assert-Equal -Actual $ReadmeSourceMatch.Groups[2].Value -Expected $UpstreamTag -Description 'README PowerShell upstream base tag'
+} else {
+  Add-AuditError 'README Current pins table is missing the PowerShell downstream source ref row.'
+}
+
+$ReadmeFrameworkMatch = [regex]::Match(
+  $ReadmeText,
+  'PowerShell target framework \| `([^`]+)`',
+  [System.Text.RegularExpressions.RegexOptions]::Multiline)
+if (-not $ReadmeFrameworkMatch.Success) {
+  Add-AuditError 'README Current pins table is missing the PowerShell target framework row.'
+}
+
+$PowerShellCommonProps = Join-Path $RepositoryRoot 'pwsh-src\PowerShell.Common.props'
+if (Test-Path -LiteralPath $PowerShellCommonProps -PathType Leaf) {
+  $PropsText = Get-Content -Raw -LiteralPath $PowerShellCommonProps
+  $TargetFramework = Get-RequiredRegexValue `
+    -Text $PropsText `
+    -Pattern '<TargetFramework>([^<]+)</TargetFramework>' `
+    -Description 'TargetFramework in pwsh-src\PowerShell.Common.props'
+
+  if ($ReadmeFrameworkMatch.Success) {
+    Assert-Equal -Actual $ReadmeFrameworkMatch.Groups[1].Value -Expected $TargetFramework -Description 'README PowerShell target framework'
+  }
+} elseif ($RequireSubmodule) {
+  Add-AuditError 'pwsh-src\PowerShell.Common.props was not found. Initialize the pwsh-src submodule before release-bump validation.'
+} else {
+  Add-AuditWarning 'pwsh-src\PowerShell.Common.props was not found; target-framework verification was skipped.'
+}
+
+if ($Warnings.Count -gt 0) {
+  Write-Warning "PowerShell pin audit completed with $($Warnings.Count) warning(s):"
+  foreach ($Warning in $Warnings) {
+    Write-Warning "  $Warning"
+  }
+}
+
+if ($Errors.Count -gt 0) {
+  foreach ($AuditError in $Errors) {
+    Write-Error $AuditError -ErrorAction Continue
+  }
+
+  throw "PowerShell pin audit failed with $($Errors.Count) error(s)."
+}
+
+Write-Host "PowerShell pin audit passed for $Version ($ReleaseTag)."

--- a/.agents/skills/powershell-release-bump/SKILL.md
+++ b/.agents/skills/powershell-release-bump/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: powershell-release-bump
+description: Coordinates PowerShell release bumps across workflow env pins, .gitmodules, README current pins, and the pwsh-src submodule pointer.
+---
+
+# powershell release bump
+
+Use this skill when moving this repository to a new upstream PowerShell release or reviewing a PR that claims to bump PowerShell.
+
+This repository requires a coordinated bump across `.github\workflows\powershell-sdk.yml`, `.github\workflows\powershell.yml`, `.gitmodules`, the `pwsh-src` submodule pointer, and README's "Current pins" table. Keep `POWERSHELL_SOURCE_REF` separate from `POWERSHELL_RELEASE_TAG`: the source ref points to `downstream/vX.Y.Z`, while the release tag remains the upstream `vX.Y.Z` value.
+
+## Prerequisites
+
+- PowerShell 7 (`pwsh`).
+- The upstream release tag should already be mirrored as `upstream/vX.Y.Z`.
+- The downstream patch branch should exist as `downstream/vX.Y.Z`.
+- Initialize `pwsh-src/` when you want the script to discover the target framework automatically.
+
+## Scripts
+
+- `scripts\Set-PowerShellReleasePins.ps1`: Updates text pins in both PowerShell workflows, `.gitmodules`, and README.
+- `..\\powershell-pin-audit\\scripts\\Test-PowerShellPins.ps1`: Audits the resulting pins after the edit.
+- `..\\..\\..\\..\\scripts\\New-PowerShellPatchBranch.ps1`: Creates a downstream branch from a mirrored upstream tag when needed.
+- `..\\..\\..\\..\\scripts\\Sync-PowerShellUpstream.ps1`: Syncs upstream refs and mirrored upstream tags.
+
+## Usage
+
+Create a downstream patch branch if it does not already exist:
+
+```powershell
+pwsh .\scripts\Sync-PowerShellUpstream.ps1 -SyncTags
+pwsh .\scripts\New-PowerShellPatchBranch.ps1 -Version 7.6.4
+```
+
+Update the repository text pins, deriving the target framework from `pwsh-src\PowerShell.Common.props`:
+
+```powershell
+pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 -Version 7.6.4
+```
+
+If the submodule is not initialized yet, pass the framework explicitly:
+
+```powershell
+pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 -Version 7.6.4 -TargetFramework net10.0
+```
+
+Preview the text edits:
+
+```powershell
+pwsh .\.agents\skills\powershell-release-bump\scripts\Set-PowerShellReleasePins.ps1 -Version 7.6.4 -TargetFramework net10.0 -WhatIf
+```
+
+Then bump the pinned source submodule commit on `master`:
+
+```powershell
+git submodule update --remote pwsh-src
+git add pwsh-src
+```
+
+Finish by auditing pins and checking the diff:
+
+```powershell
+pwsh .\.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1 -RequireSubmodule
+git --no-pager diff --check
+```
+
+## Review checklist
+
+1. Confirm both workflows use the same `POWERSHELL_VERSION`, `POWERSHELL_RELEASE_TAG`, `POWERSHELL_UPSTREAM_TAG`, and `POWERSHELL_SOURCE_REF`.
+2. Confirm `.gitmodules` has a literal `branch = downstream/vX.Y.Z` value.
+3. Confirm README current pins match the workflow values and upstream target framework.
+4. Confirm `pwsh-src` is a submodule pointer change, not a copied PowerShell source tree.
+5. Confirm generated output directories such as `output\`, `package\`, `dotnet-runtime\`, and `pwsh-src-worktree\` are not staged.

--- a/.agents/skills/powershell-release-bump/scripts/Set-PowerShellReleasePins.ps1
+++ b/.agents/skills/powershell-release-bump/scripts/Set-PowerShellReleasePins.ps1
@@ -1,0 +1,166 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [Parameter(Mandatory)]
+  [string] $Version,
+
+  [string] $TargetFramework,
+
+  [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$RepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+
+function Get-RepositoryPath {
+  param([Parameter(Mandatory)][string] $RelativePath)
+
+  return Join-Path $RepositoryRoot $RelativePath
+}
+
+function Get-RepositoryFileText {
+  param([Parameter(Mandatory)][string] $RelativePath)
+
+  $Path = Get-RepositoryPath $RelativePath
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Required file '$RelativePath' was not found."
+  }
+
+  return Get-Content -Raw -LiteralPath $Path
+}
+
+function Set-RepositoryFileText {
+  param(
+    [Parameter(Mandatory)][string] $RelativePath,
+    [Parameter(Mandatory)][string] $Text
+  )
+
+  $Path = Get-RepositoryPath $RelativePath
+  if ($PSCmdlet.ShouldProcess($RelativePath, 'Update PowerShell release pins')) {
+    Set-Content -LiteralPath $Path -Value $Text -Encoding utf8NoBOM
+  }
+}
+
+function Set-RegexValue {
+  param(
+    [Parameter(Mandatory)][string] $Text,
+    [Parameter(Mandatory)][string] $Pattern,
+    [Parameter(Mandatory)][string] $ReplacementValue,
+    [Parameter(Mandatory)][string] $Description
+  )
+
+  $Regex = [regex]::new($Pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+  $Matches = $Regex.Matches($Text)
+  if ($Matches.Count -ne 1) {
+    throw "Expected exactly one match for $Description, found $($Matches.Count)."
+  }
+
+  $Evaluator = [System.Text.RegularExpressions.MatchEvaluator] {
+    param([System.Text.RegularExpressions.Match] $Match)
+    return "$($Match.Groups[1].Value)$ReplacementValue$($Match.Groups[2].Value)"
+  }
+
+  return $Regex.Replace($Text, $Evaluator, 1)
+}
+
+function Set-YamlEnvValue {
+  param(
+    [Parameter(Mandatory)][string] $Text,
+    [Parameter(Mandatory)][string] $Name,
+    [Parameter(Mandatory)][string] $Value,
+    [Parameter(Mandatory)][string] $FileName
+  )
+
+  $EscapedName = [regex]::Escape($Name)
+  return Set-RegexValue `
+    -Text $Text `
+    -Pattern "^(\s*$EscapedName\s*:\s*)['""]?[^'""\r\n]+['""]?(\s*)$" `
+    -ReplacementValue "`"$Value`"" `
+    -Description "$Name in $FileName"
+}
+
+function Get-PowerShellTargetFramework {
+  $CommonPropsPath = Get-RepositoryPath 'pwsh-src\PowerShell.Common.props'
+  if (-not (Test-Path -LiteralPath $CommonPropsPath -PathType Leaf)) {
+    throw 'pwsh-src\PowerShell.Common.props was not found. Initialize pwsh-src or pass -TargetFramework explicitly.'
+  }
+
+  [xml] $CommonProps = Get-Content -LiteralPath $CommonPropsPath
+  $Framework = $CommonProps.Project.PropertyGroup |
+    ForEach-Object { $_.TargetFramework } |
+    Where-Object { $_ } |
+    Select-Object -First 1
+  if (-not $Framework) {
+    throw 'Unable to determine TargetFramework from pwsh-src\PowerShell.Common.props.'
+  }
+
+  return [string] $Framework
+}
+
+$NormalizedVersion = $Version.Trim()
+if ($NormalizedVersion.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+  $NormalizedVersion = $NormalizedVersion.Substring(1)
+}
+if ($NormalizedVersion -notmatch '^\d+\.\d+\.\d+$') {
+  throw "Version must be in X.Y.Z or vX.Y.Z form. Received '$Version'."
+}
+
+if (-not $TargetFramework) {
+  $TargetFramework = Get-PowerShellTargetFramework
+}
+
+$ReleaseTag = "v$NormalizedVersion"
+$UpstreamTag = "upstream/$ReleaseTag"
+$SourceRef = "downstream/$ReleaseTag"
+$ReadmeReleaseValue = "``$NormalizedVersion`` / ``$ReleaseTag``"
+$ReadmeSourceRefValue = "``$SourceRef`` based on ``$UpstreamTag``"
+$ReadmeTargetFrameworkValue = "``$TargetFramework``"
+
+$WorkflowPins = [ordered]@{
+  POWERSHELL_VERSION = $NormalizedVersion
+  POWERSHELL_RELEASE_TAG = $ReleaseTag
+  POWERSHELL_UPSTREAM_TAG = $UpstreamTag
+  POWERSHELL_SOURCE_REF = $SourceRef
+}
+
+foreach ($WorkflowPath in @('.github\workflows\powershell-sdk.yml', '.github\workflows\powershell.yml')) {
+  $WorkflowText = Get-RepositoryFileText $WorkflowPath
+  foreach ($Pin in $WorkflowPins.GetEnumerator()) {
+    $WorkflowText = Set-YamlEnvValue -Text $WorkflowText -Name $Pin.Key -Value $Pin.Value -FileName $WorkflowPath
+  }
+  Set-RepositoryFileText -RelativePath $WorkflowPath -Text $WorkflowText
+}
+
+$GitmodulesText = Get-RepositoryFileText '.gitmodules'
+$GitmodulesText = Set-RegexValue `
+  -Text $GitmodulesText `
+  -Pattern '^(\s*branch\s*=\s*)\S+(\s*)$' `
+  -ReplacementValue $SourceRef `
+  -Description 'pwsh-src branch in .gitmodules'
+Set-RepositoryFileText -RelativePath '.gitmodules' -Text $GitmodulesText
+
+$ReadmeText = Get-RepositoryFileText 'README.md'
+$ReadmeText = Set-RegexValue `
+  -Text $ReadmeText `
+  -Pattern '^(\| PowerShell upstream release \| )`[^`]+` / `[^`]+`( \|\r?)$' `
+  -ReplacementValue $ReadmeReleaseValue `
+  -Description 'README PowerShell upstream release row'
+$ReadmeText = Set-RegexValue `
+  -Text $ReadmeText `
+  -Pattern '^(\| PowerShell downstream source ref \| )`[^`]+` based on `[^`]+`( \|\r?)$' `
+  -ReplacementValue $ReadmeSourceRefValue `
+  -Description 'README PowerShell downstream source ref row'
+$ReadmeText = Set-RegexValue `
+  -Text $ReadmeText `
+  -Pattern '^(\| PowerShell target framework \| )`[^`]+`( \|\r?)$' `
+  -ReplacementValue $ReadmeTargetFrameworkValue `
+  -Description 'README PowerShell target framework row'
+Set-RepositoryFileText -RelativePath 'README.md' -Text $ReadmeText
+
+Write-Output "PowerShellVersion=$NormalizedVersion"
+Write-Output "PowerShellReleaseTag=$ReleaseTag"
+Write-Output "PowerShellUpstreamTag=$UpstreamTag"
+Write-Output "PowerShellSourceRef=$SourceRef"
+Write-Output "PowerShellTargetFramework=$TargetFramework"
+Write-Output 'NextStep=git submodule update --remote pwsh-src && git add pwsh-src'

--- a/.agents/skills/powershell-sdk-package-validate/SKILL.md
+++ b/.agents/skills/powershell-sdk-package-validate/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: powershell-sdk-package-validate
+description: Builds and validates the local single-RID Devolutions.PowerShell.SDK package using the repository's current workflow pins.
+---
+
+# powershell sdk package validate
+
+Use this skill when validating SDK packaging changes, checking a PowerShell release bump before opening a PR, or diagnosing `Devolutions.PowerShell.SDK` package layout/apphost issues.
+
+This skill wraps the repository's canonical local build script and passes values from `.github\workflows\powershell-sdk.yml`, so validation follows the same explicit pins used by GitHub Actions.
+
+## Prerequisites
+
+- PowerShell 7 (`pwsh`).
+- .NET SDK and build prerequisites required by upstream PowerShell.
+- Initialized `pwsh-src/` submodule:
+
+```powershell
+pwsh .\scripts\Initialize-Repository.ps1
+```
+
+## Scripts
+
+- `scripts\Build-AndValidateLocalPowerShellSdk.ps1`: Reads current workflow pins, runs the pin audit, then calls `scripts\Build-LocalPowerShellSdk.ps1 -Validate`.
+- `..\\powershell-pin-audit\\scripts\\Test-PowerShellPins.ps1`: Confirms pins agree before spending time on a local build.
+- `..\\..\\..\\..\\scripts\\Build-LocalPowerShellSdk.ps1`: Canonical local package build and validation implementation.
+- `..\\..\\..\\..\\eng\\Validate-PowerShellSdkPackage.ps1`: Canonical package validation script.
+
+## Usage
+
+Build and validate for the current host runtime identifier:
+
+```powershell
+pwsh .\.agents\skills\powershell-sdk-package-validate\scripts\Build-AndValidateLocalPowerShellSdk.ps1
+```
+
+Validate a specific RID supported by the local build script:
+
+```powershell
+pwsh .\.agents\skills\powershell-sdk-package-validate\scripts\Build-AndValidateLocalPowerShellSdk.ps1 -RuntimeIdentifier win-x64
+```
+
+Use a specific NuGet CLI:
+
+```powershell
+pwsh .\.agents\skills\powershell-sdk-package-validate\scripts\Build-AndValidateLocalPowerShellSdk.ps1 -NuGetExe C:\tools\nuget.exe
+```
+
+Skip the pre-build pin audit only when intentionally debugging a partially edited tree:
+
+```powershell
+pwsh .\.agents\skills\powershell-sdk-package-validate\scripts\Build-AndValidateLocalPowerShellSdk.ps1 -SkipPinAudit
+```
+
+## Expected output
+
+The canonical build writes under `output\local-sdk\<rid>\` and emits:
+
+- `package\Devolutions.PowerShell.SDK.<version>.nupkg`
+- `PowerShell-AppHost\` source-built apphost files
+- validation output proving restore, build, framework-dependent publish, self-contained publish, apphost execution, and built-in module loading
+
+Do not stage generated `output\` contents.

--- a/.agents/skills/powershell-sdk-package-validate/scripts/Build-AndValidateLocalPowerShellSdk.ps1
+++ b/.agents/skills/powershell-sdk-package-validate/scripts/Build-AndValidateLocalPowerShellSdk.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+  [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path,
+
+  [string] $RuntimeIdentifier,
+
+  [string] $OutputRoot = 'output\local-sdk',
+
+  [string] $NuGetExe,
+
+  [switch] $SkipPinAudit
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$RepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+
+function Get-RepositoryPath {
+  param([Parameter(Mandatory)][string] $RelativePath)
+
+  return Join-Path $RepositoryRoot $RelativePath
+}
+
+function Get-RepositoryFileText {
+  param([Parameter(Mandatory)][string] $RelativePath)
+
+  $Path = Get-RepositoryPath $RelativePath
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Required file '$RelativePath' was not found."
+  }
+
+  return Get-Content -Raw -LiteralPath $Path
+}
+
+function Get-YamlScalar {
+  param(
+    [Parameter(Mandatory)][string] $Text,
+    [Parameter(Mandatory)][string] $Name,
+    [Parameter(Mandatory)][string] $FileName
+  )
+
+  $EscapedName = [regex]::Escape($Name)
+  $Match = [regex]::Match(
+    $Text,
+    "^\s*$EscapedName\s*:\s*['""]?([^'""\r\n]+)['""]?\s*$",
+    [System.Text.RegularExpressions.RegexOptions]::Multiline)
+  if (-not $Match.Success) {
+    throw "Unable to find $Name in $FileName."
+  }
+
+  return $Match.Groups[1].Value.Trim()
+}
+
+$WorkflowPath = '.github\workflows\powershell-sdk.yml'
+$WorkflowText = Get-RepositoryFileText $WorkflowPath
+
+$BuildArguments = @(
+  '-PowerShellVersion', (Get-YamlScalar -Text $WorkflowText -Name 'POWERSHELL_VERSION' -FileName $WorkflowPath),
+  '-PowerShellReleaseTag', (Get-YamlScalar -Text $WorkflowText -Name 'POWERSHELL_RELEASE_TAG' -FileName $WorkflowPath),
+  '-PackageId', (Get-YamlScalar -Text $WorkflowText -Name 'SDK_PACKAGE_ID' -FileName $WorkflowPath),
+  '-VendorName', (Get-YamlScalar -Text $WorkflowText -Name 'SDK_VENDOR_NAME' -FileName $WorkflowPath),
+  '-MultiPwshPackageId', (Get-YamlScalar -Text $WorkflowText -Name 'MULTI_PWSH_APPHOST_PACKAGE_ID' -FileName $WorkflowPath),
+  '-MultiPwshPackageVersion', (Get-YamlScalar -Text $WorkflowText -Name 'MULTI_PWSH_APPHOST_PACKAGE_VERSION' -FileName $WorkflowPath),
+  '-MultiPwshPackageSource', (Get-YamlScalar -Text $WorkflowText -Name 'MULTI_PWSH_APPHOST_PACKAGE_SOURCE' -FileName $WorkflowPath),
+  '-OutputRoot', $OutputRoot,
+  '-Validate'
+)
+
+if ($RuntimeIdentifier) {
+  $BuildArguments += @('-RuntimeIdentifier', $RuntimeIdentifier)
+}
+if ($NuGetExe) {
+  $BuildArguments += @('-NuGetExe', $NuGetExe)
+}
+
+if (-not $SkipPinAudit) {
+  $PinAuditScript = Get-RepositoryPath '.agents\skills\powershell-pin-audit\scripts\Test-PowerShellPins.ps1'
+  if (-not (Test-Path -LiteralPath $PinAuditScript -PathType Leaf)) {
+    throw "Pin audit script was not found: $PinAuditScript"
+  }
+
+  & $PinAuditScript -RepositoryRoot $RepositoryRoot -RequireSubmodule
+  if (-not $?) {
+    throw 'PowerShell pin audit failed.'
+  }
+}
+
+$BuildScript = Get-RepositoryPath 'scripts\Build-LocalPowerShellSdk.ps1'
+if (-not (Test-Path -LiteralPath $BuildScript -PathType Leaf)) {
+  throw "Local SDK build script was not found: $BuildScript"
+}
+
+& $BuildScript @BuildArguments
+if (-not $?) {
+  throw 'Local PowerShell SDK build failed.'
+}

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add Claude compatibility symlinks that point to `AGENTS.md` and `.agents/skills`
- Add PowerShell pin audit, release bump, and SDK package validation agent skills
- Include wrapper scripts for coordinated pin edits and local SDK validation using existing repo scripts

## Validation
- Parsed all new PowerShell skill scripts
- Ran release-bump wrapper with `-WhatIf`
- Ran PowerShell pin audit
- Ran `git diff --check`